### PR TITLE
EVA-2083 - Release2 assembly list supporting scripts

### DIFF
--- a/tasks/eva_2083/add_ensembl_supported_assemblies.py
+++ b/tasks/eva_2083/add_ensembl_supported_assemblies.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+import re
+from argparse import ArgumentParser
+from collections import defaultdict
+
+import requests
+
+eutils_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/'
+esearch_url = eutils_url + 'esearch.fcgi'
+esummary_url = eutils_url + 'esummary.fcgi'
+efetch_url = eutils_url + 'efetch.fcgi'
+ensembl_url = 'http://rest.ensembl.org/info/assembly'
+
+cache = defaultdict(dict)
+
+
+def retrieve_species_names_from_tax_id(taxid):
+    if taxid not in cache['taxid_to_name']:
+        payload = {'db': 'Taxonomy', 'id': taxid}
+        r = requests.get(efetch_url, params=payload)
+        match = re.search('<Rank>(.+?)</Rank>', r.text, re.MULTILINE)
+        rank = None
+        if match:
+            rank = match.group(1)
+        if rank in ['species', 'subspecies']:
+            scientific_name = None
+            match = re.search('<ScientificName>(.+?)</ScientificName>', r.text, re.MULTILINE)
+            if match:
+                scientific_name = match.group(1)
+                cache['taxid_to_name'][taxid] = scientific_name
+        else:
+            print('WARNING: No species found for %s' % taxid)
+    return taxid, cache['taxid_to_name'].get(taxid)
+
+
+def retrieve_species_name_from_assembly_accession(assembly_accession):
+    if assembly_accession not in cache['assembly_to_species']:
+        payload = {'db': 'Assembly', 'term': '"{}"'.format(assembly_accession), 'retmode': 'JSON'}
+        data = requests.get(esearch_url, params=payload).json()
+        if data:
+            assembly_id_list = data.get('esearchresult').get('idlist')
+            payload = {'db': 'Assembly', 'id': ','.join(assembly_id_list), 'retmode': 'JSON'}
+            summary_list = requests.get(esummary_url, params=payload).json()
+            all_species_names = set()
+            for assembly_id in summary_list.get('result', {}).get('uids', []):
+                assembly_info = summary_list.get('result').get(assembly_id)
+                all_species_names.add((assembly_info.get('speciestaxid'), assembly_info.get('speciesname')))
+            if len(all_species_names) == 1:
+                cache['assembly_to_species'][assembly_accession] = all_species_names.pop()
+            else:
+                print('WARNING: %s taxons found for assembly %s ' % (len(all_species_names), assembly_accession))
+    return cache['assembly_to_species'].get(assembly_accession) or (None, None)
+
+
+def retrieve_current_ensembl_assemblies(source):
+    """
+    Retrieve the assembly accession currently supported by ensembl for the provided taxid or assembly accession
+    In both case it looks up the associated species name in NCBI and using the species name returns the currently
+    supported assembly for this species.
+    """
+    print('Search for species name for ' + source)
+    if str(source).isdigit():
+        taxid, scientific_name = retrieve_species_names_from_tax_id(source)
+    else:
+        taxid, scientific_name = retrieve_species_name_from_assembly_accession(source)
+
+    if scientific_name:
+        print('Found ' + scientific_name)
+        if scientific_name not in cache['scientific_name_to_ensembl']:
+            url = ensembl_url + '/' + scientific_name.lower().replace(' ', '_')
+            response = requests.get(url, params={'content-type': 'application/json'})
+            data = response.json()
+            assembly_accession = str(data.get('assembly_accession'))
+            cache['scientific_name_to_ensembl'][scientific_name] = assembly_accession
+        return [str(taxid), str(scientific_name), cache['scientific_name_to_ensembl'].get(scientific_name)]
+
+    return ['NA', 'NA', 'NA']
+
+
+def main():
+    argparse = ArgumentParser()
+    argparse.add_argument('--input', help='Path to the file containing the taxonomies and assemblies', required=True)
+    argparse.add_argument('--output', help='Path to the file that will contain the input plus annotation', required=True)
+
+    args = argparse.parse_args()
+    with open(args.input) as open_input, open(args.output, 'w') as open_ouput:
+        for line in open_input:
+            # Assume format of the input file is <assembly> <taxid> <...>
+            sp_line = line.split()
+            sp_line += retrieve_current_ensembl_assemblies(sp_line[0])
+            sp_line += retrieve_current_ensembl_assemblies(sp_line[1])
+            open_ouput.write('\t'.join(sp_line) + '\n')
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/eva_2083/count_studies.sh
+++ b/tasks/eva_2083/count_studies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+INPUT=$1
+COUNT_VAR=${INPUT%.csv}_count_variants.txt
+COUNT_STUDY=${INPUT%.csv}_count_study.txt
+COUNT_ASSEMBLY=${INPUT%.csv}_count_assembly.txt
+
+awk -F ',' '{a[$1"\t"$2"\t"$3]++} END{for (v in a){print v"\t"a[v]}}' $INPUT > $COUNT_VAR
+
+awk -F '\t' '{a[$1"\t"$2]+=$4; b[$1"\t"$2]++} END{for (v in a){print v"\t"b[v]"\t"a[v]}}' $COUNT_VAR > $COUNT_STUDY
+
+awk -F '\t' '{a[$2]+=$4; b[$2]+=$3; c[$2]++} END{for (v in a){print v"\t"c[v]"\t"b[v]"\t"a[v]}}' $COUNT_STUDY > $COUNT_ASSEMBLY

--- a/tasks/eva_2083/decision_release2.py
+++ b/tasks/eva_2083/decision_release2.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+import csv
+from argparse import ArgumentParser
+from collections import defaultdict
+
+
+def parse_input(input_file):
+    """
+    Parse the intput with a dict reader and returns the row organised per EVA/dbSNP then taxonomy id then assembly id
+    """
+    dbsnp_data = defaultdict(dict)
+    eva_data = defaultdict(dict)
+    
+    with open(input_file) as open_file:
+        reader = csv.DictReader(open_file, delimiter='\t')
+        for row in reader:
+            if row['Source'] == 'DBSNP':
+                dbsnp_data[row['Taxid']][row['Assembly']] = row
+            else:
+                eva_data[row['Taxid']][row['Assembly']] = row
+    return eva_data, dbsnp_data
+
+
+def process_eva_assemblies(eva_data, dbsnp_data):
+    """
+    This method marks EVA assemblies as included exclude them based if they match any of the following rules.
+     - A different assembly exists in dbSNP data for the same species (taxid)
+     - The assembly used in EVA is from a different species.
+     - Multiple EVA assemblies exists and this one is either not the one supported by Ensembl or has fewer variants.
+
+     Only the first two rules currently excluded any assembly.
+    """
+    for taxid in eva_data:
+        for assembly in eva_data[taxid]:
+            row = eva_data.get(taxid).get(assembly)
+            row['Decision to include'] = 'yes'
+            row['Reason'] = ''
+            if dbsnp_data.get(taxid, {}).get(assembly, {}) and len(dbsnp_data.get(taxid, {})) > 1 or \
+                    assembly not in dbsnp_data.get(taxid, {}) and len(dbsnp_data.get(taxid, {})) > 0:
+                # There is another assembly in dbSNP data that does not match the current one.
+                # That could cause the variants from EVA to not be cluster with existing dbSNP RSid
+                # which in turn could cause large number of variants to be retracted next release.
+                row['Reason'] = 'Conflicting Assembly in dbSNP for this species'
+                row['Decision to include'] = 'no'
+            elif taxid != row.get('Taxid From Assembly'):
+                # The assembly used to align these variants is not from the same taxonmy id.
+                # If we cluster these variants it could "contaminate" this assembly's variants
+                # Until we label them properly we cannot incorporate them.
+                row['Reason'] = 'Species uses assembly from a different species.'
+                row['Decision to include'] = 'no'
+
+        # Count the number of assembly left
+        assemblies_left = [
+            local_assembly
+            for local_assembly in eva_data.get(taxid)
+            if eva_data[taxid][local_assembly]['Decision to include'] == 'yes'
+        ]
+        if len(assemblies_left) > 1:
+            # We cannot release both assemblies so select the one associated with which supported by Ensembl.
+            # If none are supported then release the one that has the most variants
+            ensembl_assocaited_assembly = [
+                local_assembly
+                for local_assembly in assemblies_left
+                if eva_data[taxid][local_assembly].get('Ensembl Assembly From Taxid') == local_assembly
+            ]
+            if ensembl_assocaited_assembly:
+                assembly_to_keep = ensembl_assocaited_assembly[0]
+                reason = 'Multiple EVA assemblies, can only choose one, so chose one that match Ensembl'
+            else:
+                assembly_to_keep = sorted(
+                    assemblies_left,
+                    key=lambda local_assembly: int(eva_data[taxid][local_assembly]['Number Of Variants']),
+                )[-1]
+                reason = 'Multiple EVA assemblies, can only choose one, so chose one with most variants'
+
+            assemblies_left.remove(assembly_to_keep)
+            for assembly in assemblies_left:
+                row = eva_data.get(taxid).get(assembly)
+                row['Reason'] = reason
+                row['Decision to include'] = 'no'
+
+
+def process_dbsnp_assemblies(eva_data, dbsnp_data):
+    """
+    This method marks dbSNP assemblies as included
+    """
+    for taxid in dbsnp_data:
+        for assembly in dbsnp_data[taxid]:
+            row = dbsnp_data.get(taxid).get(assembly)
+            row['Decision to include'] = 'yes'
+            row['Reason'] = 'Was released previously an need to be released again'
+
+
+def write_output(output_file, eva_data, dbsnp_data):
+    output_headers = [
+        'Source', 'Assembly', 'Taxid', 'number Of Study', 'Number Of Variants', 
+        'Taxid From Assembly', 'Scientific Name From Assembly', 'Ensembl Assembly From Assembly', 
+        'Taxid From Taxid', 'Scientific Name From Taxid', 'Ensembl Assembly From Taxid',
+        'Decision to include', 'Reason'
+    ]
+    with open(output_file, 'w') as open_file:
+        writer = csv.DictWriter(open_file, fieldnames=output_headers, delimiter='\t')
+        writer.writeheader()
+        for taxid in eva_data:
+            for assembly in eva_data[taxid]:
+                writer.writerow(eva_data[taxid][assembly])
+        for taxid in dbsnp_data:
+            for assembly in dbsnp_data[taxid]:
+                writer.writerow(dbsnp_data[taxid][assembly])
+
+
+def main():
+    argparse = ArgumentParser()
+    argparse.add_argument('--input', help='Path to the file containing the taxonomies and assemblies', required=True)
+    argparse.add_argument('--output', help='Path to the file that will contain the input plus annotation', required=True)
+
+    args = argparse.parse_args()
+    
+    eva_data, dbsnp_data = parse_input(args.input)
+    process_eva_assemblies(eva_data, dbsnp_data )
+    process_dbsnp_assemblies(eva_data, dbsnp_data)
+    write_output(args.output, eva_data, dbsnp_data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/eva_2083/decision_release2.py
+++ b/tasks/eva_2083/decision_release2.py
@@ -23,7 +23,7 @@ def parse_input(input_file):
 
 def process_eva_assemblies(eva_data, dbsnp_data):
     """
-    This method marks EVA assemblies as included exclude them based if they match any of the following rules.
+    This method marks EVA assemblies as included or excluded. Will exclude them if they match any of the following rules.
      - A different assembly exists in dbSNP data for the same species (taxid)
      - The assembly used in EVA is from a different species.
      - Multiple EVA assemblies exists and this one is either not the one supported by Ensembl or has fewer variants.
@@ -58,7 +58,7 @@ def process_eva_assemblies(eva_data, dbsnp_data):
         if len(assemblies_left) > 1:
             # We cannot release both assemblies so select the one associated with which supported by Ensembl.
             # If none are supported then release the one that has the most variants
-            ensembl_assocaited_assembly = [
+            ensembl_associated_assembly = [
                 local_assembly
                 for local_assembly in assemblies_left
                 if eva_data[taxid][local_assembly].get('Ensembl Assembly From Taxid') == local_assembly
@@ -93,7 +93,7 @@ def process_dbsnp_assemblies(eva_data, dbsnp_data):
 
 def write_output(output_file, eva_data, dbsnp_data):
     output_headers = [
-        'Source', 'Assembly', 'Taxid', 'number Of Study', 'Number Of Variants', 
+        'Source', 'Assembly', 'Taxid', 'Number Of Studies', 'Number Of Variants', 
         'Taxid From Assembly', 'Scientific Name From Assembly', 'Ensembl Assembly From Assembly', 
         'Taxid From Taxid', 'Scientific Name From Taxid', 'Ensembl Assembly From Taxid',
         'Decision to include', 'Reason'

--- a/tasks/eva_2083/tests/test_decision_release2.py
+++ b/tasks/eva_2083/tests/test_decision_release2.py
@@ -1,0 +1,59 @@
+import os
+from unittest import TestCase
+from tasks.eva_2083.decision_release2 import process_eva_assemblies
+
+
+class TestDecisionRelease2(TestCase):
+
+    species_list = os.path.join(os.path.dirname(os.path.abspath(__file__)), "combined_from_mongoprod_count_study_annotated.tsv")
+
+    def test_process_eva_assemblies(self):
+
+        # No corresponding assembly in dbSNP and Assembly taxonomy matches data's taxonomy
+        eva_data = {'1000': {'asm1': {'Taxid From Assembly': '1000'}}}
+        dbsnp_data = {}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'yes')
+
+        # Matching assembly in dbSNP and Assembly taxonomy matches data's taxonomy
+        eva_data = {'1000': {'asm1': {'Taxid From Assembly': '1000'}}}
+        dbsnp_data = {'1000': {'asm1': {}}}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'yes')
+
+        # Conflicting assembly in dbSNP and Assembly taxonomy matches data's taxonomy
+        eva_data = {'1000': {'asm1': {'Taxid From Assembly': '1000'}}}
+        dbsnp_data = {'1000': {'asm2': {}}}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'no')
+        self.assertEqual(eva_data['1000']['asm1']['Reason'], 'Conflicting Assembly in dbSNP for this species')
+
+        # No corresponding assembly in dbSNP but Assembly taxonomy does not match data's taxonomy
+        eva_data = {'1000': {'asm1': {'Taxid From Assembly': '1001'}}}
+        dbsnp_data = {}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'no')
+        self.assertEqual(eva_data['1000']['asm1']['Reason'], 'Species uses assembly from a different species.')
+
+        # Multiple EVA assemblies, first one matches Ensembl supported assembly
+        eva_data = {'1000': {
+            'asm1': {'Taxid From Assembly': '1000', 'Ensembl Assembly From Taxid': 'asm1', 'Number Of Variants': '10'},
+            'asm2': {'Taxid From Assembly': '1000', 'Ensembl Assembly From Taxid': 'asm1', 'Number Of Variants': '11'}
+        }}
+        dbsnp_data = {}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'yes')
+        self.assertEqual(eva_data['1000']['asm2']['Decision to include'], 'no')
+        self.assertEqual(eva_data['1000']['asm2']['Reason'], 'Multiple EVA assemblies, can only choose one, so chose one that match Ensembl')
+
+        # Multiple EVA assemblies, second ones has more variants
+        eva_data = {'1000': {
+            'asm1': {'Taxid From Assembly': '1000', 'Number Of Variants': '10'},
+            'asm2': {'Taxid From Assembly': '1000', 'Number Of Variants': '11'}
+        }}
+        dbsnp_data = {}
+        process_eva_assemblies(eva_data, dbsnp_data)
+        self.assertEqual(eva_data['1000']['asm1']['Decision to include'], 'no')
+        self.assertEqual(eva_data['1000']['asm1']['Reason'],
+                         'Multiple EVA assemblies, can only choose one, so chose one with most variants')
+        self.assertEqual(eva_data['1000']['asm2']['Decision to include'], 'yes')


### PR DESCRIPTION
Add scripts to:
 - summarise the mongo dumps, 
 - annotated each entry with Ensembl supported assemblies 
 - Annotate each assembly with decision to be included in release or not