### PR TITLE
EVA-2287 Use genbank accession for chromosome

### DIFF
--- a/tasks/eva_2287/correct_contig_with_chr_removed.py
+++ b/tasks/eva_2287/correct_contig_with_chr_removed.py
@@ -28,7 +28,7 @@ def correct(private_config_xml_file, profile='production', mongo_database='eva_a
                 original_id = get_SHA1(variant)
                 assert variant['_id'] == original_id, "Original id is different from the one calculated %s != %s" % (
                     variant['_id'], original_id)
-                variant['contig'] = 'chromosome11'
+                variant['contig'] = 'CM008482.1'
                 variant['_id'] = get_SHA1(variant)
                 insert_statements.append(pymongo.InsertOne(variant))
                 drop_statements.append(pymongo.DeleteOne({'_id': original_id}))

--- a/tasks/eva_2287/test/test_correct_chr_prefix.py
+++ b/tasks/eva_2287/test/test_correct_chr_prefix.py
@@ -41,8 +41,8 @@ class TestCorrectChr(TestCase):
         self.assertEqual(fixed, 1)
         variant = (self.connection_handle[self.database][self.variant_collection].find_one(
             {'seq': 'GCA_002742125.1'}))
-        self.assertEqual(variant['contig'], 'chromosome11')
-        self.assertEqual(variant['_id'], '55392EB026F670F15823A9BEF16DD45398371124')
+        self.assertEqual(variant['contig'], 'CM008482.1')
+        self.assertEqual(variant['_id'], '65656369EF7C856ADF57AEDAFD5E6075E8575D84')
         variant = (self.connection_handle[self.database][self.variant_collection].find_one(
             {'_id': '616766226DF5A3852B9FE4B266B641421CAF4BE6'}))
         self.assertIsNone(variant)


### PR DESCRIPTION
Change to use genbank accession for the chromosome. I didn't use the chromosome name in PR #21 but we store them in mongo with the genbank convention