### PR TITLE
EVA-2641: first part of remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+__pycache__/
+venv/

--- a/tasks/eva_2641/cleanup_annotation_metadata.py
+++ b/tasks/eva_2641/cleanup_annotation_metadata.py
@@ -1,0 +1,39 @@
+import argparse
+
+from ebi_eva_common_pyutils.logger import logging_config
+from ebi_eva_common_pyutils.mongo_utils import get_mongo_connection_handle
+
+from tasks.eva_2641.constants import annotation_metadata_collection_name, temp_collection_name
+
+logger = logging_config.get_logger(__name__)
+logging_config.add_stdout_handler()
+
+
+def cleanup_metadata(settings_xml_file, db_name):
+    with get_mongo_connection_handle('production', settings_xml_file) as mongo_conn:
+        db = mongo_conn[db_name]
+        metadata_collection = db[annotation_metadata_collection_name]
+        temp_collection = db[temp_collection_name]
+
+        results = [x for x in metadata_collection.find({'ct': {'$exists': True}})]
+        insert_result = temp_collection.insert_many(results)
+        logger.info(f'Inserted {len(insert_result.inserted_ids)} documents into {temp_collection_name}')
+        delete_result = metadata_collection.delete_many(results)
+        logger.info(f'Deleted {delete_result.deleted_count} documents from {annotation_metadata_collection_name}')
+        metadata_collection.drop_indexes()
+        logger.info(f'Dropped non-id indexes from {annotation_metadata_collection_name}')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Cleanup metadata collection by removing annotation documents to a temporary collection and '
+                    'removing unnecessary indexes', add_help=False)
+    parser.add_argument('--settings-xml-file', required=True)
+    parser.add_argument('--db-name', required=True)
+
+    args = parser.parse_args()
+    cleanup_metadata(args.settings_xml_file, args.db_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/eva_2641/constants.py
+++ b/tasks/eva_2641/constants.py
@@ -1,0 +1,3 @@
+annotation_metadata_collection_name = 'annotationMetadata_2_0'
+annotations_collection_name = 'annotations_2_0'
+temp_collection_name = 'eva2641_temp_annotations'

--- a/tasks/eva_2641/list_affected_dbs.py
+++ b/tasks/eva_2641/list_affected_dbs.py
@@ -1,0 +1,33 @@
+import argparse
+
+from ebi_eva_common_pyutils.mongo_utils import get_mongo_connection_handle
+
+from tasks.eva_2641.constants import annotation_metadata_collection_name
+
+
+def get_affected_dbs(settings_xml_file):
+    affected_dbs = []
+    with get_mongo_connection_handle('production', settings_xml_file) as mongo_conn:
+        for db_name in mongo_conn.list_database_names():
+            if not db_name.startswith('eva_'):
+                continue
+            coll = mongo_conn[db_name][annotation_metadata_collection_name]
+            count = coll.count_documents({'ct': {'$exists': True}})
+            if count > 0:
+                affected_dbs.append((db_name, count))
+    return affected_dbs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Get list of databases with annotations in the wrong collection', add_help=False)
+    parser.add_argument('--settings-xml-file', required=True)
+
+    args = parser.parse_args()
+    dbs = get_affected_dbs(args.settings_xml_file)
+    for db, count in dbs:
+        print(db, ':', count)
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks/eva_2641/requirements.txt
+++ b/tasks/eva_2641/requirements.txt
@@ -1,0 +1,2 @@
+ebi_eva_common_pyutils
+pymongo


### PR DESCRIPTION
Clean up annotation metadata collections from affected databases by removing documents containing `ct` attribute and inserting them into a temporary collection.