### PR TITLE
EVA-2862 - Remediate remapped duplicate dbsnp SS

### DIFF
--- a/tasks/eva_2862/ExportNewlySplitSS.groovy
+++ b/tasks/eva_2862/ExportNewlySplitSS.groovy
@@ -97,9 +97,7 @@ class ExportNewlySplitSS implements CommandLineRunner {
     @Retryable(value = MongoCursorNotFoundException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
     List<? extends SubmittedVariantEntity> getNextBatchOfSplitEvaSVEs(
             List<? extends SubmittedVariantOperationEntity> operations) {
-        List<Long> accessions = operations.stream()
-                                          .map(SubmittedVariantOperationEntity::getSplitInto)
-                                          .collect(Collectors.toList())
+        List<Long> accessions = operations.collect{ it.getSplitInto() }
         Query queryToGetNextBatchOfSVE = query(where("accession").in(accessions)
                 .and("remappedFrom").exists(false))
         List<? extends SubmittedVariantEntity> result = this.mongoTemplate.find(queryToGetNextBatchOfSVE,

--- a/tasks/eva_2862/ExportNewlySplitSS.groovy
+++ b/tasks/eva_2862/ExportNewlySplitSS.groovy
@@ -1,0 +1,123 @@
+@Grab(group = 'uk.ac.ebi.eva', module = 'eva-accession-core', version = '0.6.10-SNAPSHOT')
+@Grab(group = 'uk.ac.ebi.eva', module = 'eva-remapping-get-source', version = '0.6.10-SNAPSHOT')
+
+import com.mongodb.MongoCursorNotFoundException
+import htsjdk.variant.variantcontext.VariantContext;
+import org.apache.commons.lang3.tuple.ImmutablePair
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+import uk.ac.ebi.eva.accession.remapping.source.configuration.batch.io.VariantContextWriterConfiguration
+import uk.ac.ebi.eva.accession.remapping.source.configuration.batch.io.SubmittedVariantsProcessorConfiguration
+import uk.ac.ebi.eva.accession.remapping.source.configuration.InputParametersConfiguration
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantOperationEntity
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+
+@Component
+@Import(value=[VariantContextWriterConfiguration.class, SubmittedVariantsProcessorConfiguration.class,
+               InputParametersConfiguration.class, MongoConfiguration.class])
+class ExportNewlySplitSS implements CommandLineRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExportNewlySplitSS.class)
+
+    @Autowired
+    private MongoTemplate mongoTemplate
+
+    @Autowired
+    private InputParameters inputParameters
+
+    @Autowired
+    private ItemProcessor<SubmittedVariantEntity, VariantContext> submittedVariantProcessor
+
+    @Autowired
+    private VariantContextWriter variantContextWriter
+
+    void run(String... args) {
+        // Steps:
+        // - read from dbSNP SS operations matching SS_SPLIT_FROM_X_TO_Y
+        // - for each Y, get the EVA SS entities with accession Y
+        // - process and write variant to VCF using existing processor & writer
+
+        int numSplitOperations = 0
+        int batchIndex = 0
+        String lastSeenID = null
+        while (true) {
+            ImmutablePair<List<? extends SubmittedVariantOperationEntity>, String> splitOperationsAndLastSeenID =
+                    getNextBatchOfSplitOperations(lastSeenID)
+            if (splitOperationsAndLastSeenID != null) {
+                List<? extends SubmittedVariantEntity> sves = 
+                        getNextBatchOfSplitEvaSVEs(splitOperationsAndLastSeenID.left)
+                if (sves != null) {
+                    variantContextWriter.write(submittedVariantProcessor.process(sves))
+                }
+                numSplitOperations += splitOperationsAndLastSeenID.left.size()
+                lastSeenID = splitOperationsAndLastSeenID.right
+                logger.info("Processed " + numSplitOperations + " split operations...")
+                batchIndex += 1
+            } else {
+                break
+            }
+        }
+    }
+
+    @Retryable(value = MongoCursorNotFoundException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
+    ImmutablePair<List<? extends SubmittedVariantOperationEntity>, String> getNextBatchOfSplitOperations(
+            String lastSeenID) {
+        Query queryToGetNextBatchOfSVO = query(where("_id").regex("^SS_SPLIT_.+")
+                .and("inactiveObjects.seq").is(inputParameters.getAssemblyAccession()))
+        if (Objects.nonNull(lastSeenID)) {
+            queryToGetNextBatchOfSVO.addCriteria(where("_id").gt(lastSeenID))
+        }
+        queryToGetNextBatchOfSVO = queryToGetNextBatchOfSVO.with(Sort.by(Sort.Direction.ASC, "_id")).limit(1000)
+
+        List<? extends SubmittedVariantOperationEntity> result =
+                this.mongoTemplate.find(queryToGetNextBatchOfSVO, DbsnpSubmittedVariantOperationEntity.class)
+        if (result.size() > 0) {
+            return new ImmutablePair<>(result, result.get(result.size() - 1).getId())
+        }
+        return null
+    }
+
+    @Retryable(value = MongoCursorNotFoundException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
+    List<? extends SubmittedVariantEntity> getNextBatchOfSplitEvaSVEs(
+            List<? extends SubmittedVariantOperationEntity> operations) {
+        List<Long> accessions = operations.stream()
+                                          .map(SubmittedVariantOperationEntity::getSplitInto)
+                                          .collect(Collectors.toList())
+        Query queryToGetNextBatchOfSVE = query(where("accession").in(accessions)
+                .and("remappedFrom").exists(false))
+        List<? extends SubmittedVariantEntity> result = this.mongoTemplate.find(queryToGetNextBatchOfSVE,
+                SubmittedVariantEntity.class)
+        if (result.size() > 0) {
+            return result
+        }
+        return null
+    }
+
+}
+
+@SpringBootApplication
+class ExportNewlySplitSSApp  {
+
+    static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(ExportNewlySplitSS.class, args)
+        System.exit(SpringApplication.exit(context))
+    }
+
+}

--- a/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
+++ b/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
@@ -9,9 +9,6 @@ import org.springframework.batch.item.ItemReader
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.CommandLineRunner
-import org.springframework.boot.SpringApplication
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Import
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Query
@@ -19,12 +16,13 @@ import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
 import uk.ac.ebi.eva.accession.clustering.batch.processors.VariantToSubmittedVariantEntityProcessor
-import uk.ac.ebi.eva.accession.clustering.configuration.batch.processors.CluteringVariantProcessorConfiguration
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.processors.ClusteringVariantProcessorConfiguration
+import uk.ac.ebi.eva.accession.clustering.parameters.InputParameters
 import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration
 import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity
 import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
 import uk.ac.ebi.eva.remapping.ingest.configuration.batch.io.VcfReaderConfiguration
-import uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames;
+import uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames
 import uk.ac.ebi.eva.remapping.ingest.configuration.InputParametersConfiguration
 
 import static org.springframework.data.mongodb.core.query.Criteria.where
@@ -131,17 +129,6 @@ class PropagateSplitToRemappedSS implements CommandLineRunner {
         }
 
         return updatedSVE
-    }
-
-}
-
-
-@SpringBootApplication
-class PropagateSplitToRemappedSSApp  {
-
-    static void main(String[] args) {
-        ConfigurableApplicationContext context = SpringApplication.run(PropagateSplitToRemappedSS.class, args)
-        System.exit(SpringApplication.exit(context))
     }
 
 }

--- a/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
+++ b/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
@@ -1,0 +1,149 @@
+@Grab(group = 'uk.ac.ebi.eva', module = 'eva-accession-clustering', version = '0.6.10-SNAPSHOT')
+@Grab(group = 'uk.ac.ebi.eva', module = 'eva-accession-core', version = '0.6.10-SNAPSHOT')
+@Grab(group = 'uk.ac.ebi.eva', module = 'eva-remapping-ingest', version = '0.6.10-SNAPSHOT')
+
+import com.mongodb.MongoCursorNotFoundException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.batch.item.ItemReader
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+import uk.ac.ebi.eva.accession.clustering.batch.processors.VariantToSubmittedVariantEntityProcessor
+import uk.ac.ebi.eva.accession.clustering.configuration.batch.processors.CluteringVariantProcessorConfiguration
+import uk.ac.ebi.eva.accession.core.configuration.nonhuman.MongoConfiguration
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.remapping.ingest.configuration.batch.io.VcfReaderConfiguration
+import uk.ac.ebi.eva.remapping.ingest.configuration.BeanNames;
+import uk.ac.ebi.eva.remapping.ingest.configuration.InputParametersConfiguration
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+
+@Component
+@Import(value=[VcfReaderConfiguration.class, CluteringVariantProcessorConfiguration.class,
+               InputParametersConfiguration.class, MongoConfiguration.class])
+class PropagateSplitToRemappedSS implements CommandLineRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(PropagateSplitToRemappedSS.class)
+
+    @Autowired
+    private MongoTemplate mongoTemplate
+
+    @Autowired
+    private InputParameters inputParameters
+
+    @Autowired
+    @Qualifier(BeanNames.VCF_READER)
+    private ItemReader<Variant> vcfReader
+
+    @Autowired
+    private VariantToSubmittedVariantEntityProcessor variantProcessor
+    
+
+    void run(String... args) {
+        // Steps:
+        // - read from remapped vcf
+        // - for each variant, compute the hash and get the corresponding document from dbSNP SVE
+        // - update the SS while preserving everything else
+        // - insert to EVA SVE
+        // - delete originals from dbSNP SVE
+
+        int chunkSize = 1000
+        int count = 0
+        List<SubmittedVariantEntity> chunk = new ArrayList<>()
+
+        Variant variant = vcfReader.read()
+
+        while (variant != null) {
+            SubmittedVariantEntity sve = variantProcessor.process(variant)
+
+            if (count < chunkSize) {
+                chunk.add(sve)
+                count++
+            } else {
+                processChunk(chunk)
+                count = 0
+                chunk = new ArrayList<>()
+            }
+            variant = vcfReader.read()
+        }
+
+        // process the last chunk, if it exists
+        if (!chunk.isEmpty()) {
+            processChunk(chunk)
+        }
+    }
+
+    void processChunk(List<? extends SubmittedVariantEntity> chunk) {
+        List<? extends SubmittedVariantEntity> remappedSVEWithOldSS = getSVEWithSameHash(chunk)
+        if (remappedSVEWithOldSS != null) {
+            List<SubmittedVariantEntity> remappedSVEWithUpdatedSS = getUpdatedSVE(remappedSVEWithOldSS, sve)
+            mongoTemplate.insert(remappedSVEWithUpdatedSS, SubmittedVariantEntity.class)
+            mongoTemplate.findAndRemove(remappedSVEWithOldSS, DbsnpSubmittedVariantEntity.class)
+        }
+}
+
+    @Retryable(value = MongoCursorNotFoundException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
+    List<? extends SubmittedVariantEntity> getSVEWithSameHash(List<? extends SubmittedVariantEntity> sves) {
+        List<String> hashes = sves.stream()
+                                  .map(SubmittedVariantEntity::getHashedMessage)
+                                  .collect(Collectors.toList())
+        Query queryToGetNextBatchOfSVE = query(where("_id").in(hashes))
+        List<? extends SubmittedVariantEntity> result = this.mongoTemplate.find(queryToGetNextBatchOfSVE,
+                DbsnpSubmittedVariantEntity.class)
+        if (result.size() > 0) {
+            return result
+        }
+        return null
+    }
+
+    List<? extends SubmittedVariantEntity> getUpdatedSVE(List<? extends SubmittedVariantEntity> sveWithOldSS,
+                                                         SubmittedVariantEntity sveWithNewSS) {
+        Long newSS = sveWithNewSS.getAccession()
+        List<SubmittedVariantEntity> updatedSVE = new ArrayList<>()
+        for (SubmittedVariantEntity sve : sveWithOldSS) {
+            SubmittedVariant variant = new SubmittedVariant(
+                sve.getReferenceSequenceAccession(),
+                sve.getTaxonomyAccession(),
+                sve.getProjectAccession(),
+                sve.getContig(),
+                sve.getStart(),
+                sve.getReferenceAllele(),
+                sve.getAlternateAllele(),
+                sve.getClusteredVariantAccession())  // preserve RSID from the old SVE
+            updatedSVE.add(new SubmittedVariantEntity(
+                newSS, 
+                sve.getHashedMessage(),
+                variant,
+                sve.getVersion(),
+                sve.getRemappedFrom(), 
+                sve.getRemappedDate(),
+                sve.getRemappingId()))
+        }
+
+        return updatedSVE
+    }
+
+}
+
+
+@SpringBootApplication
+class PropagateSplitToRemappedSSApp  {
+
+    static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(PropagateSplitToRemappedSS.class, args)
+        System.exit(SpringApplication.exit(context))
+    }
+
+}

--- a/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
+++ b/tasks/eva_2862/PropagateSplitToRemappedSS.groovy
@@ -96,9 +96,7 @@ class PropagateSplitToRemappedSS implements CommandLineRunner {
 
     @Retryable(value = MongoCursorNotFoundException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
     List<? extends SubmittedVariantEntity> getSVEWithSameHash(List<? extends SubmittedVariantEntity> sves) {
-        List<String> hashes = sves.stream()
-                                  .map(SubmittedVariantEntity::getHashedMessage)
-                                  .collect(Collectors.toList())
+        List<String> hashes = sves.collect{ it.getHashedMessage() }
         Query queryToGetNextBatchOfSVE = query(where("_id").in(hashes))
         List<? extends SubmittedVariantEntity> result = this.mongoTemplate.find(queryToGetNextBatchOfSVE,
                 DbsnpSubmittedVariantEntity.class)

--- a/tasks/eva_2862/get_custom_assembly.py
+++ b/tasks/eva_2862/get_custom_assembly.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+
+# Copyright 2019 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import os
+import re
+import shutil
+import sys
+import urllib
+from copy import copy
+from csv import DictReader, excel_tab, DictWriter
+from typing import List, Dict
+
+from cached_property import cached_property
+from ebi_eva_common_pyutils.config import cfg
+from ebi_eva_common_pyutils.logger import AppLogger, logging_config
+from ebi_eva_common_pyutils.metadata_utils import get_metadata_connection_handle
+from ebi_eva_common_pyutils.pg_utils import get_all_results_for_query
+from retry import retry
+
+sys.path.append(os.path.dirname(__file__))
+
+from remapping_config import load_config
+
+
+class CustomAssembly(AppLogger):
+    """
+    This class creates a custom assembly based on existing assembly fasta and report.
+    It adds additional contigs provided by the required_contigs function after checking that they are not already in
+    the assembly.
+    """
+    def __init__(self, assembly_accession, assembly_fasta_path, assembly_report_path, eutils_api_key=None):
+        self.assembly_accession = assembly_accession
+        self.assembly_fasta_path = assembly_fasta_path
+        self.assembly_report_path = assembly_report_path
+        self.eutils_api_key = eutils_api_key or cfg.get('eutils_api_key')
+        self.assembly_report_headers = None
+
+    @property
+    def output_assembly_report_path(self):
+        base, ext = os.path.splitext(self.assembly_report_path)
+        return base + '_custom' + ext
+
+    @property
+    def output_assembly_fasta_path(self):
+        base, ext = os.path.splitext(self.assembly_fasta_path)
+        return base + '_custom' + ext
+
+    @property
+    def assembly_directory(self):
+        return os.path.dirname(self.assembly_fasta_path)
+
+    @cached_property
+    def required_contigs(self) -> List[Dict]:
+        """
+        The contigs that are required to be added to the custom assembly. This provides a list of dict where each dict
+        contains at least one key call 'genbank' and the value should be the INSDC accession of the sequence.
+        The only other key supported is refseq.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_assembly_report(assembly_report):
+        """Parse the assembly report and return each row as a dict."""
+        headers = None
+        with open(assembly_report) as open_file:
+            # Parse the assembly report file to find the header then stop
+            for line in open_file:
+                if line.lower().startswith("# sequence-name") and "sequence-role" in line.lower():
+                    headers = line.strip().split('\t')
+                    break
+            reader = DictReader(open_file, fieldnames=headers, dialect=excel_tab)
+            return headers, [record for record in reader]
+
+    @cached_property
+    def assembly_report_rows(self):
+        """Provides assembly report rows with each row as a dict."""
+        headers, rows = self._get_assembly_report(self.assembly_report_path)
+        self.assembly_report_headers = headers
+        return rows
+
+    @cached_property
+    def extended_report_rows(self):
+        """Provide the list of assembly report rows extended with additional ones if there are any."""
+        if self.genbank_contig_to_add:
+            extended_report_rows = copy(self.assembly_report_rows)
+            for contig_dict in self.genbank_contig_to_add:
+                row = {
+                    "# Sequence-Name": contig_dict['genbank'],
+                    "Sequence-Role": "scaffold",
+                    "GenBank-Accn": contig_dict['genbank'],
+                    'Relationship': '<>'
+                }
+                if 'refseq' in contig_dict:
+                    row['RefSeq-Accn'] = contig_dict['refseq']
+                    row['Relationship'] = '='
+                extended_report_rows.append(row)
+        else:
+            extended_report_rows = self.assembly_report_rows
+        return extended_report_rows
+
+    @cached_property
+    def genbank_contig_to_add(self):
+        genbank_contigs = set(row['GenBank-Accn'] for row in self.assembly_report_rows)
+        return [contig_dict for contig_dict in self.required_contigs if contig_dict['genbank'] not in genbank_contigs]
+
+    @staticmethod
+    def get_contig_accessions_in_fasta(fasta_path):
+        written_contigs = []
+        match = re.compile(r'>(.*?)\s')
+        if os.path.isfile(fasta_path):
+            with open(fasta_path, 'r') as file:
+                for line in file:
+                    written_contigs.extend(match.findall(line))
+        return written_contigs
+
+    @retry(tries=4, delay=2, backoff=1.2, jitter=(1, 3))
+    def download_contig_from_ncbi(self, contig_accession):
+        sequence_tmp_path = os.path.join(self.assembly_directory, contig_accession + '.fa')
+        parameters = {
+            'db': 'nuccore',
+            'id': contig_accession,
+            'rettype': 'fasta',
+            'retmode': 'text',
+            'tool': 'eva',
+            'email': 'eva-dev@ebi.ac.uk'
+        }
+        if self.eutils_api_key:
+            parameters['api_key'] = self.eutils_api_key
+        url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?' + urllib.parse.urlencode(parameters)
+        self.info('Downloading ' + contig_accession)
+        urllib.request.urlretrieve(url, sequence_tmp_path)
+        return sequence_tmp_path
+
+    def generate_assembly_report(self):
+        if self.genbank_contig_to_add:
+            self.info(f'Create custom assembly report for {self.assembly_accession}')
+            with open(self.output_assembly_report_path, 'w') as open_output:
+                writer = DictWriter(open_output, fieldnames=self.assembly_report_headers,  dialect=excel_tab, restval='na')
+                writer.writeheader()
+                for row in self.extended_report_rows:
+                    writer.writerow(row)
+        else:
+            os.symlink(self.assembly_report_path, self.output_assembly_report_path)
+
+    def generate_fasta(self):
+        """
+        Check if custom contig needs to be added to the assembly. If yes then copy the fasta file and append the new
+        contigs otherwise create a symlink to the normal assembly.
+        """
+        if self.genbank_contig_to_add:
+            self.info(f'Create custom assembly fasta for {self.assembly_accession}')
+            written_contigs = self.get_contig_accessions_in_fasta(self.assembly_fasta_path)
+            # Now find out what are the contigs that needs to be appended to the assembly
+            contig_to_append = []
+            for contig_dict in self.genbank_contig_to_add:
+                if contig_dict['genbank'] not in written_contigs:
+                    contig_to_append.append(self.download_contig_from_ncbi(contig_dict['genbank']))
+            if contig_to_append:
+                shutil.copy(self.assembly_fasta_path, self.output_assembly_fasta_path, follow_symlinks=True)
+                with open(self.output_assembly_fasta_path, 'a+') as fasta:
+                    for contig_path in contig_to_append:
+                        with open(contig_path) as sequence:
+                            for line in sequence:
+                                # Check that the line is not empty
+                                if line.strip():
+                                    fasta.write(line)
+                        os.remove(contig_path)
+            else:
+                os.symlink(self.assembly_fasta_path, self.output_assembly_fasta_path)
+        else:
+            os.symlink(self.assembly_fasta_path, self.output_assembly_fasta_path)
+
+
+class CustomAssemblyFromDatabase(CustomAssembly):
+
+    @cached_property
+    def required_contigs(self):
+        """Return list of dict retrieve from the eva_tasks.eva2469_contig_analysis table."""
+        self.info('Retrieve required contigs from database')
+        with get_metadata_connection_handle(cfg['maven']['environment'], cfg['maven']['settings_file']) as pg_conn:
+            query = ("select distinct contig_accession,refseq_contig_from_equiv_table from eva_tasks.eva2469_contig_analysis "
+                     "where source_table in ('dbsnpSubmittedVariantEntity', 'submittedVariantEntity') "
+                     f"and assembly_accession='{self.assembly_accession}'")
+            return [dict([
+                ('genbank', genbank_accession.strip() if genbank_accession else ''),
+                ('refseq', refseq_accession.strip() if refseq_accession else '')
+            ]) for genbank_accession, refseq_accession in get_all_results_for_query(pg_conn, query)]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate custom assembly report for a given assembly',
+                                     add_help=False)
+    parser.add_argument("-a", "--assembly-accession",
+                        help="Assembly for which the process has to be run, e.g. GCA_000002315.3",
+                        required=True)
+    parser.add_argument("-f", "--fasta-file", help="Path to the fasta file containing the assembly", required=True)
+    parser.add_argument("-r", "--report-file",
+                        help="Path to the assembly report file containing the assembly", required=True)
+    parser.add_argument('--help', action='help', help='Show this help message and exit')
+
+    args = parser.parse_args()
+
+    load_config()
+    logging_config.add_stdout_handler()
+
+    assembly = CustomAssemblyFromDatabase(args.assembly_accession, args.fasta_file, args.report_file)
+    assembly.generate_assembly_report()
+    assembly.generate_fasta()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/eva_2862/remapping_config.py
+++ b/tasks/eva_2862/remapping_config.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import os
+
+import yaml
+from ebi_eva_common_pyutils.config import Configuration, cfg
+
+
+def load_config(*args):
+    """
+    Load a config file from any path provided.
+    If none are provided then read from a file path provided in the environment variable REMAPPINGCONFIG.
+    If not provided then default to .remapping_config.yml place in the current users' home
+    """
+    cfg.load_config_file(
+        *args,
+        os.getenv('REMAPPINGCONFIG'),
+        os.path.expanduser('~/.remapping_config.yml'),
+    )

--- a/tasks/eva_2862/remediate.nf
+++ b/tasks/eva_2862/remediate.nf
@@ -134,7 +134,7 @@ process extract_vcf_from_mongo {
     echo "parameters.assemblyAccession=${params.source_assembly_accession}" >> ${params.source_assembly_accession}_extraction.properties
     echo "parameters.outputFolder=." >> ${params.source_assembly_accession}_extraction.properties
 
-    spring run $params.groovy.split_ss_export --spring.config.name=${params.source_assembly_accession}_extraction > ${params.source_assembly_accession}_vcf_extractor.log
+    export SPRING_CONFIG_LOCATION=${params.source_assembly_accession}_extraction.properties && spring run $params.groovy.split_ss_export > ${params.source_assembly_accession}_vcf_extractor.log
     """
 }
 
@@ -213,6 +213,6 @@ process ingest_vcf_into_mongo {
     fi
     echo "parameters.assemblyReportUrl=file:${target_report}" >> ${remapped_vcf}_ingestion.properties
 
-    spring run $params.groovy.split_ss_propagate --spring.config.name=${remapped_vcf}_ingestion > ${remapped_vcf}_ingestion.log
+    export SPRING_CONFIG_LOCATION=${remapped_vcf}_ingestion.properties && spring run $params.groovy.split_ss_propagate > ${remapped_vcf}_ingestion.log
     """
 }

--- a/tasks/eva_2862/remediate.nf
+++ b/tasks/eva_2862/remediate.nf
@@ -1,0 +1,218 @@
+#!/usr/bin/env nextflow
+
+// Adapted from https://github.com/EBIvariation/eva-tools/blob/master/variant-remapping-automation/remapping_process.nf
+// Only change is to modify extract and ingest processes to use groovy scripts
+
+def helpMessage() {
+    log.info"""
+    Remap submitted variant from one assembly version to another.
+
+    Inputs:
+            --taxonomy_id                   taxonomy id of submitted variants that needs to be remapped.
+            --source_assembly_accession     assembly accession of the submitted variants are currently mapped to.
+            --target_assembly_accession     assembly accession the submitted variants will be remapped to.
+            --species_name                  scientific name to be used for the species.
+            --genome_assembly_dir           path to the directory where the genome should be downloaded.
+            --template_properties           path to the template properties file.
+            --output_dir                    path to the directory where the output file should be copied.
+            --remapping_config              path to the remapping configuration file
+    """
+}
+
+params.source_assembly_accession = null
+params.target_assembly_accession = null
+params.species_name = null
+// help
+params.help = null
+
+// Show help message
+if (params.help) exit 0, helpMessage()
+
+// Test input files
+if (!params.taxonomy_id || !params.source_assembly_accession || !params.target_assembly_accession || !params.species_name || !params.genome_assembly_dir ) {
+    if (!params.taxonomy_id) log.warn('Provide the taxonomy id of the source submitted variants using --taxonomy_id')
+    if (!params.source_assembly_accession) log.warn('Provide the source assembly using --source_assembly_accession')
+    if (!params.target_assembly_accession) log.warn('Provide the target assembly using --target_assembly_accession')
+    if (!params.species_name) log.warn('Provide a species name using --species_name')
+    if (!params.genome_assembly_dir) log.warn('Provide a path to where the assembly should be downloaded using --genome_assembly_dir')
+    exit 1, helpMessage()
+}
+
+
+species_name = params.species_name.toLowerCase().replace(" ", "_")
+
+
+process retrieve_source_genome {
+
+    output:
+    path "${params.source_assembly_accession}.fa" into source_fasta
+    path "${params.source_assembly_accession}_assembly_report.txt" into source_report
+
+    """
+    $params.executable.genome_downloader --assembly-accession ${params.source_assembly_accession} --species ${species_name} --output-directory ${params.genome_assembly_dir}
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.source_assembly_accession}/${params.source_assembly_accession}.fa
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.source_assembly_accession}/${params.source_assembly_accession}_assembly_report.txt
+    """
+}
+
+
+process retrieve_target_genome {
+
+    output:
+    path "${params.target_assembly_accession}.fa" into target_fasta
+    path "${params.target_assembly_accession}_assembly_report.txt" into target_report
+
+    """
+    $params.executable.genome_downloader --assembly-accession ${params.target_assembly_accession} --species ${species_name} --output-directory ${params.genome_assembly_dir}
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.target_assembly_accession}/${params.target_assembly_accession}.fa
+    ln -s ${params.genome_assembly_dir}/${species_name}/${params.target_assembly_accession}/${params.target_assembly_accession}_assembly_report.txt
+    """
+}
+
+process update_source_genome {
+
+    input:
+    path source_fasta from source_fasta
+    path source_report from source_report
+    env REMAPPINGCONFIG from params.remapping_config
+
+    output:
+    path  "${source_fasta.getBaseName()}_custom.fa" into updated_source_fasta
+    path  "${source_report.getBaseName()}_custom.txt" into updated_source_report
+
+    """
+    source $params.executable.python_activate
+    $baseDir/get_custom_assembly.py --assembly-accession ${params.source_assembly_accession} --fasta-file ${source_fasta} --report-file ${source_report}
+    """
+}
+
+process update_target_genome {
+
+    input:
+    path target_fasta from target_fasta
+    path target_report from target_report
+    env REMAPPINGCONFIG from params.remapping_config
+
+    output:
+    path "${target_fasta.getBaseName()}_custom.fa" into updated_target_fasta
+    path "${target_report.getBaseName()}_custom.txt" into updated_target_report
+
+    """
+    source $params.executable.python_activate
+    $baseDir/get_custom_assembly.py --assembly-accession ${params.target_assembly_accession} --fasta-file ${target_fasta} --report-file ${target_report}
+    """
+}
+
+
+
+/*
+ * Extract the submitted variants to remap from the accesioning warehouse and store them in a VCF file.
+ */
+process extract_vcf_from_mongo {
+    memory '8GB'
+
+    input:
+    path source_fasta from updated_source_fasta
+    path source_report from updated_source_report
+
+    output:
+    path "${params.source_assembly_accession}_extraction.properties" into extraction_props
+    // Store both vcfs (eva and dbsnp) into one channel
+    path '*.vcf' into source_vcfs
+    path "${params.source_assembly_accession}_vcf_extractor.log" into log_filename
+
+    publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    """
+    cp ${params.template_properties} ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.projects=" >> ${params.source_assembly_accession}_extraction.properties
+    echo "spring.batch.job.names=EXPORT_SUBMITTED_VARIANTS_JOB" >> ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.fasta=${source_fasta}" >> ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.taxonomy=${params.taxonomy_id}" >> ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.assemblyReportUrl=file:${source_report}" >> ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.assemblyAccession=${params.source_assembly_accession}" >> ${params.source_assembly_accession}_extraction.properties
+    echo "parameters.outputFolder=." >> ${params.source_assembly_accession}_extraction.properties
+
+    spring run $params.groovy.split_ss_export --spring.config.name=${params.source_assembly_accession}_extraction > ${params.source_assembly_accession}_vcf_extractor.log
+    """
+}
+
+
+/*
+ * variant remmapping pipeline
+ */
+process remap_variants {
+
+    memory '8GB'
+
+    input:
+    path source_fasta from updated_source_fasta
+    path target_fasta from updated_target_fasta
+    path source_vcf from source_vcfs.flatten()
+
+    output:
+    path "${basename_source_vcf}_remapped.vcf" into remapped_vcfs
+    path "${basename_source_vcf}_remapped_unmapped.vcf" into unmapped_vcfs
+    path "${basename_source_vcf}_remapped_counts.yml" into remapped_ymls
+
+    publishDir "$params.output_dir/eva", overwrite: true, mode: "copy", pattern: "*_eva_remapped*"
+    publishDir "$params.output_dir/dbsnp", overwrite: true, mode: "copy", pattern: "*_dbsnp_remapped*"
+
+    script:
+    basename_source_vcf = source_vcf.getBaseName()
+    """
+    # Setup the PATH so that the variant remapping pipeline can access its dependencies
+    mkdir bin
+    for P in $params.executable.bcftools $params.executable.samtools $params.executable.bedtools $params.executable.minimap2 $params.executable.bgzip $params.executable.tabix
+      do ln -s \$P bin/
+    done
+    PATH=`pwd`/bin:\$PATH
+    source $params.executable.python_activate
+    # Nextflow needs the full path to the input parameters hence the pwd
+    $params.executable.nextflow run $params.nextflow.remapping -resume \
+      --oldgenome `pwd`/${source_fasta} \
+      --newgenome `pwd`/${target_fasta} \
+      --vcffile `pwd`/${source_vcf} \
+      --outfile `pwd`/${basename_source_vcf}_remapped.vcf
+    """
+}
+
+/*
+ * Ingest the remapped submitted variants from a VCF file into the accessioning warehouse.
+ */
+process ingest_vcf_into_mongo {
+    memory '8GB'
+
+    input:
+    path remapped_vcf from remapped_vcfs.flatten()
+    path target_report from updated_target_report
+
+    output:
+    path "${remapped_vcf}_ingestion.properties" into ingestion_props
+    path "${remapped_vcf}_ingestion.log" into ingestion_log_filename
+
+    publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"
+    publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
+
+    script:
+    """
+    cp ${params.template_properties} ${remapped_vcf}_ingestion.properties
+    echo "spring.batch.job.names=INGEST_REMAPPED_VARIANTS_FROM_VCF_JOB" >> ${remapped_vcf}_ingestion.properties
+    echo "parameters.vcf=${remapped_vcf}" >> ${remapped_vcf}_ingestion.properties
+    echo "parameters.assemblyAccession=${params.target_assembly_accession}" >> ${remapped_vcf}_ingestion.properties
+    echo "parameters.remappedFrom=${params.source_assembly_accession}" >> ${remapped_vcf}_ingestion.properties
+    echo "parameters.remappingVersion=1.0" >> ${remapped_vcf}_ingestion.properties
+    echo "parameters.chunkSize=100" >> ${remapped_vcf}_ingestion.properties
+    # Check the file name to know which database to load the variants into
+    if [[ $remapped_vcf == *_eva_remapped.vcf ]]
+    then
+        echo "parameters.loadTo=EVA" >> ${remapped_vcf}_ingestion.properties
+    else
+        echo "parameters.loadTo=DBSNP" >> ${remapped_vcf}_ingestion.properties
+    fi
+    echo "parameters.assemblyReportUrl=file:${target_report}" >> ${remapped_vcf}_ingestion.properties
+
+    spring run $params.groovy.split_ss_propagate --spring.config.name=${remapped_vcf}_ingestion > ${remapped_vcf}_ingestion.log
+    """
+}

--- a/tasks/eva_2862/run_remediation.py
+++ b/tasks/eva_2862/run_remediation.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+import os
+import subprocess
+from argparse import ArgumentParser
+
+import yaml
+from ebi_eva_common_pyutils import command_utils
+from ebi_eva_common_pyutils.config import cfg
+from ebi_eva_common_pyutils.config_utils import get_primary_mongo_creds_for_profile, get_accession_pg_creds_for_profile
+from ebi_eva_common_pyutils.logger import logging_config
+from ebi_eva_common_pyutils.metadata_utils import get_metadata_connection_handle
+from ebi_eva_common_pyutils.pg_utils import get_all_results_for_query
+
+
+logger = logging_config.get_logger(__name__)
+logging_config.add_stdout_handler()
+
+
+def write_remapping_process_props_template(template_file_path):
+    mongo_host, mongo_user, mongo_pass = get_primary_mongo_creds_for_profile(cfg['maven']['environment'],
+                                                                             cfg['maven']['settings_file'])
+    pg_url, pg_user, pg_pass = get_accession_pg_creds_for_profile(cfg['maven']['environment'],
+                                                                  cfg['maven']['settings_file'])
+    with open(template_file_path, 'w') as open_file:
+        open_file.write(f'''spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url={pg_url}
+spring.datasource.username={pg_user}
+spring.datasource.password={pg_pass}
+spring.datasource.tomcat.max-active=3
+
+spring.jpa.generate-ddl=true
+
+spring.data.mongodb.host={mongo_host}
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=eva_accession_sharded
+spring.data.mongodb.username={mongo_user}
+spring.data.mongodb.password={mongo_pass}
+
+spring.data.mongodb.authentication-database=admin
+mongodb.read-preference=secondaryPreferred
+spring.main.web-environment=false
+spring.main.allow-bean-definition-overriding=true
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+logging.level.uk.ac.ebi.eva.accession.remapping=INFO
+parameters.chunkSize=1000
+''')
+    return template_file_path
+
+
+def process_one_taxonomy(assembly, taxid, scientific_name, target_assembly, resume):
+    base_directory = cfg['remapping']['base_directory']
+    nextflow_remapping_process = os.path.join(os.path.dirname(__file__), 'remediate.nf')
+    assembly_directory = os.path.join(base_directory, taxid, assembly)
+    work_dir = os.path.join(assembly_directory, 'work')
+    prop_template_file = os.path.join(assembly_directory, 'template.properties')
+    os.makedirs(work_dir, exist_ok=True)
+
+    remapping_log = os.path.join(assembly_directory, 'remapping_process.log')
+    remapping_config_file = os.path.join(assembly_directory, 'remapping_process_config_file.yaml')
+    remapping_config = {
+        'taxonomy_id': taxid,
+        'source_assembly_accession': assembly,
+        'target_assembly_accession': target_assembly,
+        'species_name': scientific_name,
+        'output_dir': assembly_directory,
+        'genome_assembly_dir': cfg['genome_downloader']['output_directory'],
+        'template_properties': write_remapping_process_props_template(prop_template_file),
+        'remapping_config': cfg.config_file
+    }
+    for part in ['executable', 'nextflow', 'groovy']:
+        remapping_config[part] = cfg[part]
+    with open(remapping_config_file, 'w') as open_file:
+        yaml.safe_dump(remapping_config, open_file)
+
+    try:
+        command = [
+            cfg['executable']['nextflow'],
+            '-log', remapping_log,
+            'run', nextflow_remapping_process,
+            '-params-file', remapping_config_file,
+            '-work-dir', work_dir
+        ]
+        if resume:
+            command.append('-resume')
+        curr_working_dir = os.getcwd()
+        os.chdir(assembly_directory)
+        command_utils.run_command_with_output('Nextflow remapping process', ' '.join(command))
+    except subprocess.CalledProcessError as e:
+        logger.error('Nextflow remapping pipeline failed')
+        raise e
+    finally:
+        os.chdir(curr_working_dir)
+
+
+def process_one_assembly(assembly, resume):
+    # Check the original remapping tracking table for the appropriate taxonomies and target assemblies
+    query = (
+        'SELECT taxonomy, scientific_name, assembly_accession'
+        'FROM eva_progress_tracker.remapping_tracker '
+        f"WHERE origin_assembly_accession='{assembly}'"
+        "AND source='DBSNP'"
+    )
+    with get_metadata_connection_handle(cfg['maven']['environment'], cfg['maven']['settings_file']) as pg_conn:
+        for taxid, scientific_name, target_assembly in get_all_results_for_query(pg_conn, query):
+            process_one_taxonomy(assembly, taxid, scientific_name, target_assembly, resume)
+
+
+def main():
+    argparse = ArgumentParser(description='Run remediation for one assembly')
+    argparse.add_argument('--assembly', help='Source assembly to remediate')
+    argparse.add_argument('--resume', action='store_true', default=False)
+
+    args = argparse.parse_args()
+    cfg.load_config_file(os.getenv('REMAPPINGCONFIG'))
+    
+    process_one_assembly(args.assembly, args.resume)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/eva_2862/run_remediation.py
+++ b/tasks/eva_2862/run_remediation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 import yaml
@@ -12,6 +13,9 @@ from ebi_eva_common_pyutils.logger import logging_config
 from ebi_eva_common_pyutils.metadata_utils import get_metadata_connection_handle
 from ebi_eva_common_pyutils.pg_utils import get_all_results_for_query
 
+sys.path.append(os.path.dirname(__file__))
+
+from remapping_config import load_config
 
 logger = logging_config.get_logger(__name__)
 logging_config.add_stdout_handler()
@@ -114,11 +118,8 @@ def main():
     argparse.add_argument('--resume', action='store_true', default=False)
 
     args = argparse.parse_args()
-    cfg.load_config_file(os.getenv('REMAPPINGCONFIG'))
-    
-    # TODO make sure it's safe to run this on everything in the tracking table
-    #  (i.e. most of the time it should correctly do nothing)
-    #  otherwise we need a way to figure out which assemblies to run it on
+    load_config()
+
     process_one_assembly(args.assembly, args.resume)
 
 

--- a/tasks/eva_2862/run_remediation.py
+++ b/tasks/eva_2862/run_remediation.py
@@ -48,6 +48,7 @@ mongodb.read-preference=secondaryPreferred
 spring.main.web-environment=false
 spring.main.allow-bean-definition-overriding=true
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+spring.main.web-application-type=none
 logging.level.uk.ac.ebi.eva.accession.remapping=INFO
 parameters.chunkSize=1000
 ''')


### PR DESCRIPTION
[WIP, not ready for review]

Guide for review:
* `ExportNewlySplitSS.groovy` and `PropagateSplitToRemappedSS.groovy` are new scripts
* `run_remediation.py` is a new top-level runner script, loosely based on the [original remapping automation runner](https://github.com/EBIvariation/eva-tools/blob/master/variant-remapping-automation/remapping_automation.py) but simplified and operating per assembly rather than assembly/taxonomy pair
* `remapping_config.py` and `get_custom_assembly.py` are taken directly from the [original automation](https://github.com/EBIvariation/eva-tools/tree/master/variant-remapping-automation) with no changes
* `remediate.nf` is also taken directly from the original remapping automation EXCEPT with the export and ingestion tools replaced by groovy scripts - you can view this diff [here](https://www.diffchecker.com/jE9Yd9oR)
