### PR TITLE
EVA-2936 - Scripts to copy data to DEV, deprecate and QC the results

### DIFF
--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/DuplicateSSCategory.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/DuplicateSSCategory.groovy
@@ -1,0 +1,40 @@
+package src
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.index.Indexed
+import org.springframework.data.mongodb.core.mapping.Document
+import uk.ac.ebi.ampt2d.commons.accession.hashing.SHA1HashingFunction
+
+@Document
+class DuplicateSSCategory {
+    @Id
+    String id
+
+    @Indexed
+    Long accession
+
+    @Indexed
+    String seq
+    String category
+
+    protected DuplicateSSCategory() {
+    }
+
+    DuplicateSSCategory(Long accession, String seq, String category) {
+        this.accession = accession
+        this.seq = seq
+        this.category = category
+        this.id = new SHA1HashingFunction().apply("${this.accession}_${this.seq}_${this.category}")
+    }
+
+
+    @Override
+    public String toString() {
+        return "DuplicateSSCategory{" +
+                "id='" + id + '\'' +
+                ", accession=" + accession +
+                ", seq='" + seq + '\'' +
+                ", category='" + category + '\'' +
+                '}'
+    }
+}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/EVADataSet.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/EVADataSet.groovy
@@ -1,0 +1,116 @@
+package src
+
+import org.apache.commons.lang3.tuple.ImmutablePair
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessResourceFailureException
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.aggregation.Aggregation
+import org.springframework.data.mongodb.core.query.CriteriaDefinition
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+
+class EVADataSet<T,T2> implements Iterable<T> {
+    CriteriaDefinition filterCriteria
+    Aggregation aggregation
+    MongoTemplate mongoTemplate
+    final Class<T> collectionClass
+    String pagingAttribute
+    final Class<T2> pagingAttributeType
+    List<T> currentResult = new ArrayList<>()
+
+    private int numEntriesScanned = 0
+    private int batchIndex = 0
+    private T2 lastSeenID = null
+
+    private static final Logger logger = LoggerFactory.getLogger(EVADataSet.class)
+
+    EVADataSet() {}
+
+    EVADataSet(CriteriaDefinition filterCriteria, MongoTemplate mongoTemplate, Class<T> collectionClass,
+               String pagingAttribute = "_id", Class<T2> pagingAttributeType = String.class) {
+        this.filterCriteria = filterCriteria
+        this.mongoTemplate = mongoTemplate
+        this.collectionClass = collectionClass
+        this.pagingAttribute = pagingAttribute
+        this.pagingAttributeType = pagingAttributeType
+    }
+
+    EVADataSet(Aggregation aggregation, MongoTemplate mongoTemplate, Class<T> collectionClass,
+               String pagingAttribute = "_id") {
+        this.aggregation = aggregation
+        this.mongoTemplate = mongoTemplate
+        this.collectionClass = collectionClass
+        this.pagingAttribute = pagingAttribute
+    }
+
+    @Override
+    public Iterator<List<T>> iterator() {
+        return new Iterator<List<T>>() {
+            @Override
+            boolean hasNext() {
+                getNextBatch()
+                boolean result = !(Objects.isNull(this.currentResult))
+                if (!result) reset()
+                return result
+            }
+
+            @Override
+            List<T> next() {
+                return this.currentResult
+            }
+        }
+    }
+
+    private void reset() {
+        this.lastSeenID = null
+        this.batchIndex = 0
+        this.numEntriesScanned = 0
+    }
+
+    public void getNextBatch() {
+        ImmutablePair<List<T>, T2> resultPair = Objects.isNull(this.aggregation)? getNextBatchWithFind(): null
+        if (resultPair != null) {
+            this.numEntriesScanned += resultPair.left.size()
+            this.lastSeenID = resultPair.right
+            this.batchIndex += 1
+            logger.debug("${this.numEntriesScanned} entries of ${collectionClass.getSimpleName()} collection scanned so far...")
+            this.currentResult = resultPair.left
+            return
+        }
+        this.currentResult = null
+    }
+
+    @Retryable(value = DataAccessResourceFailureException.class, maxAttempts = 5, backoff = @Backoff(delay = 100L))
+    private ImmutablePair<List<T>, T2> getNextBatchWithFind() {
+        Query queryToGetNextBatch = new Query()
+        if (Objects.nonNull(this.filterCriteria)) {
+            queryToGetNextBatch.addCriteria(this.filterCriteria)
+        }
+        if (Objects.nonNull(this.lastSeenID)) {
+            queryToGetNextBatch.addCriteria(where(pagingAttribute).gt(this.lastSeenID))
+        }
+        queryToGetNextBatch = queryToGetNextBatch.with(Sort.by(Sort.Direction.ASC, pagingAttribute)).limit(1000)
+        def result = this.mongoTemplate.find(queryToGetNextBatch, this.collectionClass)
+        if (result.size() > 0) {
+            return new ImmutablePair<>(result, result.get(result.size() - 1).getProperties()
+                    .get(this.pagingAttribute.equals("_id")? "id":this.pagingAttribute))
+        }
+        return null
+    }
+
+    public void copyTo(EVADatabaseEnvironment targetDBEnv) {
+        this.each {List<T> dbEntities ->
+            def entitiesToInsert = dbEntities.groupBy {dbEntity -> dbEntity.getId()};
+            def alreadyExistingInTarget = targetDBEnv.mongoTemplate.find(query(where("_id").in(entitiesToInsert.keySet())),
+                    this.collectionClass).collect{dbEntity -> dbEntity.getId()}.toSet();
+            entitiesToInsert = entitiesToInsert.findAll {k, v -> !alreadyExistingInTarget.contains(k)};
+            targetDBEnv.mongoTemplate.insert(entitiesToInsert.values().flatten(), this.collectionClass)
+        }
+    }
+}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/EVADatabaseEnvironment.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/EVADatabaseEnvironment.groovy
@@ -1,0 +1,148 @@
+package src
+
+import com.mongodb.MongoClient
+import com.mongodb.MongoClientOptions
+import com.mongodb.ReadConcern
+import com.mongodb.ReadPreference
+import com.mongodb.WriteConcern
+import org.springframework.boot.autoconfigure.mongo.MongoClientFactory
+import org.springframework.boot.autoconfigure.mongo.MongoProperties
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.env.PropertiesPropertySource
+import org.springframework.core.env.StandardEnvironment
+import org.springframework.data.mapping.model.SimpleTypeHolder
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.SimpleMongoDbFactory
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext
+import org.springframework.data.mongodb.core.mapping.MongoSimpleTypes
+import org.springframework.data.mongodb.core.query.Query
+import uk.ac.ebi.eva.accession.core.service.nonhuman.ClusteredVariantAccessioningService
+import uk.ac.ebi.eva.accession.core.service.nonhuman.SubmittedVariantAccessioningService
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+import static org.springframework.data.mongodb.core.query.Query.query;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+// This class is to create an environment for EVA databases from a given properties file
+// We do this instead of Spring Boot autowiring because Spring boot
+// doesn't support multiple application contexts to hold properties
+// for multiple environments (ex: prod and dev) at the same time
+// Most of the code below is borrowed from MongoConfiguration in the eva-accession repository
+public class EVADatabaseEnvironment {
+    MongoClient mongoClient
+    MongoTemplate mongoTemplate
+    SubmittedVariantAccessioningService submittedVariantAccessioningService
+    ClusteredVariantAccessioningService clusteredVariantAccessioningService
+    AnnotationConfigApplicationContext springApplicationContext
+
+    EVADatabaseEnvironment(MongoClient mongoClient, MongoTemplate mongoTemplate,
+                           SubmittedVariantAccessioningService submittedVariantAccessioningService,
+                           ClusteredVariantAccessioningService clusteredVariantAccessioningService,
+                           AnnotationConfigApplicationContext springApplicationContext) {
+        this.mongoClient = mongoClient
+        this.mongoTemplate = mongoTemplate
+        this.submittedVariantAccessioningService = submittedVariantAccessioningService
+        this.clusteredVariantAccessioningService = clusteredVariantAccessioningService
+        this.springApplicationContext = springApplicationContext
+    }
+
+    EVADatabaseEnvironment(MongoClient mongoClient, MongoTemplate mongoTemplate) {
+        this.mongoClient = mongoClient
+        this.mongoTemplate = mongoTemplate
+    }
+
+    public final <T3> void bulkUpsert(List<T3> docsToInsert, Class<T3> documentClass) {
+        if (docsToInsert.size() > 0) {
+            def docsToInsertGrouped = docsToInsert.groupBy { it.getId() }
+            def docsExisting = this.mongoTemplate.find(query(where("_id").in(docsToInsertGrouped.keySet())),
+                    documentClass).collect { it.getId() }.toSet()
+            docsToInsertGrouped.removeAll { k, v -> docsExisting.contains(k) }
+            this.mongoTemplate.insert(docsToInsertGrouped.values().flatten(), documentClass)
+        }
+    }
+
+    static EVADatabaseEnvironment createFromSpringContext(String propertiesFile, Class springApplicationClass) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()
+        def appProps = new Properties()
+        appProps.load(new FileInputStream(new File(propertiesFile)))
+        context.getEnvironment().getPropertySources().addLast(new PropertiesPropertySource("main", appProps))
+        context.register(springApplicationClass)
+        context.refresh()
+
+        def mc = context.getBean(MongoClient.class)
+        def mt = context.getBean(MongoTemplate.class)
+        def sva = context.getBean(SubmittedVariantAccessioningService.class)
+        def cva = context.getBean(ClusteredVariantAccessioningService.class)
+        return new EVADatabaseEnvironment(mc, mt, sva, cva, context)
+    }
+
+    static EVADatabaseEnvironment parseFrom(String propertiesFile) {
+        def properties = new Properties()
+        properties.load(new FileInputStream(new File(propertiesFile)))
+        MongoProperties mongoProperties = getMongoPropertiesForEnv(properties)
+        MongoClient mongoClient = getMongoClientForEnv(properties, mongoProperties)
+        MongoTemplate mongoTemplate = getMongoTemplateForEnv(mongoClient, mongoProperties)
+
+        return new EVADatabaseEnvironment(mongoClient, mongoTemplate)
+    }
+
+    private static MongoClient getMongoClientForEnv(Properties properties, MongoProperties mongoProperties) {
+        def readPreference = ReadPreference.valueOf(properties.getProperty("mongodb.read-preference"))
+        def mongoClientOptions = new MongoClientOptions.Builder().readPreference(readPreference).writeConcern(WriteConcern.MAJORITY).readConcern(ReadConcern.MAJORITY)
+
+        def environment = new StandardEnvironment()
+        def mongoClient = new MongoClientFactory(mongoProperties, environment).createMongoClient(mongoClientOptions.build())
+        mongoClient
+    }
+
+    private static MongoProperties getMongoPropertiesForEnv(Properties properties) {
+        def mongoProperties = new MongoProperties()
+        mongoProperties.setDatabase(properties.getProperty("spring.data.mongodb.database"))
+        mongoProperties.setHost(properties.getProperty("spring.data.mongodb.host"))
+        mongoProperties.setPort(Integer.parseInt(properties.getProperty("spring.data.mongodb.port")))
+        mongoProperties.setUsername(properties.getProperty("spring.data.mongodb.username"))
+        mongoProperties.setPassword(properties.getProperty("spring.data.mongodb.password").toCharArray())
+        mongoProperties.setAuthenticationDatabase(properties.getProperty("spring.data.mongodb.authentication-database"))
+        return mongoProperties
+    }
+
+    private static MongoTemplate getMongoTemplateForEnv(MongoClient mongoClient, MongoProperties mongoProperties) {
+        def mongoDbFactory = new SimpleMongoDbFactory(mongoClient, mongoProperties.getDatabase())
+        def mappingContext = new MongoMappingContext()
+        SimpleTypeHolder simpleTypeHolder = new SimpleTypeHolder(new HashSet<>(Arrays.asList(
+                Date.class,
+                LocalDateTime.class
+        )), MongoSimpleTypes.HOLDER)
+        mappingContext.setSimpleTypeHolder(simpleTypeHolder)
+        def mappingMongoConverter = new MappingMongoConverter(new DefaultDbRefResolver(mongoDbFactory), mappingContext)
+        mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null))
+        List<Converter<?, ?>> converterList = new ArrayList<Converter<?, ?>>()
+        converterList.add(new MongoLocalDateTimeFromStringConverter())
+        converterList.add(new MongoDateTimeFromStringConverter())
+        mappingMongoConverter.setMapKeyDotReplacement("#")
+        mappingMongoConverter.afterPropertiesSet()
+        return new MongoTemplate(mongoDbFactory, mappingMongoConverter)
+    }
+
+    private static final class MongoLocalDateTimeFromStringConverter implements Converter<String, LocalDateTime> {
+        @Override
+        LocalDateTime convert(String source) {
+            return source == null ? null : LocalDateTime.parse(source)
+        }
+    }
+
+    private static final class MongoDateTimeFromStringConverter implements Converter<String, Date> {
+        @Override
+        Date convert(String source) {
+            return source == null ? null :
+                    Date.from(LocalDateTime.parse(source).toLocalDate()
+                            .atStartOfDay(ZoneId.systemDefault()).toInstant())
+        }
+    }
+}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/copy_data_to_eva2936_dev_env.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/copy_data_to_eva2936_dev_env.groovy
@@ -1,0 +1,128 @@
+package src
+
+@Grab(group = 'org.apache.commons', module = 'commons-csv', version = '1.9.0')
+@Grab(group='org.codehaus.groovy', module='groovy-cli-commons', version='3.0.10')
+
+import org.apache.commons.csv.*
+import org.slf4j.LoggerFactory
+import src.EVADatabaseEnvironment
+import src.EVADataSet
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpClusteredVariantEntity
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity
+import uk.ac.ebi.eva.accession.core.model.eva.ClusteredVariantEntity
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.deprecate.Application
+
+
+def cli = new CliBuilder(usage: 'copy_data_to_eva2936_dev_env <TSV folder with duplicates report> <dev properties file> <prod properties file>')
+def options = cli.parse(args)
+if (options.arguments().size() != 3) {
+    cli.usage()
+    return
+}
+
+def duplicateSSReportDir = options.arguments()[0]
+def devPropertiesFile = options.arguments()[1]
+def prodPropertiesFile = options.arguments()[2]
+
+def prodEnv = EVADatabaseEnvironment.createFromSpringContext(prodPropertiesFile, Application.class)
+def eva2936DevEnv = EVADatabaseEnvironment.createFromSpringContext(devPropertiesFile, Application.class)
+def evaSSAccessionsLowerBound = eva2936DevEnv.springApplicationContext.getBean("accessioningMonotonicInitSs", Long.class)
+def evaRSAccessionsLowerBound = eva2936DevEnv.springApplicationContext.getBean("accessioningMonotonicInitRs", Long.class)
+def logger = LoggerFactory.getLogger(this.class)
+def categoriesForDbsnpDuplicateSS =
+        ["In_original_assembly,Multi_position_ssid,Remapped,Same_variants_in_source",
+         "In_original_assembly,Multi_allele_ssid,Remapped,Same_variants_in_source",
+         "Multi_allele_ssid,Multi_position_in_source,Remapped",
+         "Multi_allele_in_source,Multi_allele_ssid,Remapped",
+         "Multi_position_in_source,Multi_position_ssid,Remapped",
+         "In_original_assembly,Multi_position_in_source,Multi_position_ssid,Remapped",
+         "Multi_allele_in_source,Multi_position_ssid,Remapped",
+         "In_original_assembly,Multi_allele_in_source,Multi_position_ssid,Remapped"]
+def filesWithDuplicateSS = ["dbsnp_analysis", "eva_analysis"].collect{category ->
+    new FileNameByRegexFinder().getFileNames(duplicateSSReportDir + "/" + category, /.*_duplicates_annotated\.tsv/)}
+
+// load duplicate report to Mongo - so that we don't have to grep these every time an accession needs to be looked up
+filesWithDuplicateSS.each { category ->
+    category.each { fileName ->
+        new File(fileName).withReader { reader ->
+            logger.info("Processing file ${fileName}...")
+            CSVParser csv = new CSVParser(reader, CSVFormat.TDF)
+            csv.findAll { csvRecord ->
+                categoriesForDbsnpDuplicateSS.contains(csvRecord.get(2).trim())
+            }.collect { obj -> (CSVRecord) obj }
+                    .collate(1000)
+                    .each { csvRecords ->
+                        def docsToInsert = csvRecords.collect { csvRecord ->
+                            new DuplicateSSCategory(csvRecord[0].toLong(), csvRecord[1].toString(),
+                                    csvRecord[2].toString())
+                        }
+                        logger.info("Inserting ${docsToInsert.size()} documents...")
+                        eva2936DevEnv.bulkUpsert(docsToInsert, DuplicateSSCategory.class)
+                    }
+        }
+    }
+}
+
+// load duplicate SS to Mongo
+def duplicateReports = new EVADataSet(null, eva2936DevEnv.mongoTemplate, DuplicateSSCategory.class)
+duplicateReports.each {List<DuplicateSSCategory> categories ->
+    def ssGroupedByAssembly = categories.groupBy {it.seq}
+    ssGroupedByAssembly.each {assembly, categoriesInAssembly ->
+        def ssIDs = categoriesInAssembly.collect{it.accession}
+        // Groupby clause below will only look for variants that satisfy category 1 through 3 criteria here: https://docs.google.com/spreadsheets/d/1LZbUtamFtQH12SVTfCfYOjcIHWL1OOC_kYnieRLR9UA/edit#rangeid=1722186521
+        // i.e., EVA remapped variants with accession collisions on existing variants from dbSNP (category 1) OR from multiple source assemblies (category 2) OR both
+        def svesToInsert = prodEnv.submittedVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, ssIDs)
+                .groupBy {it.getAccession()}.findAll { k, v -> return v.collect {
+                                                        it.getData().getRemappedFrom() }.unique().size() > 1}
+                .values().flatten().collect{new SubmittedVariantEntity(it.getAccession(), it.getHash(), it.getData(),
+                it.getVersion())}
+        if (svesToInsert.size() > 0) {
+            def dbsnpSVEsToInsert = svesToInsert.findAll{it.getAccession() < evaSSAccessionsLowerBound}
+            def evaSVEsToInsert = svesToInsert.findAll{it.getAccession() >= evaSSAccessionsLowerBound}
+            logger.info("Inserting ${dbsnpSVEsToInsert.size()} to DbsnpSubmittedVariantEntity in DEV...")
+            logger.info("Inserting ${evaSVEsToInsert.size()} to SubmittedVariantEntity in DEV...")
+            eva2936DevEnv.bulkUpsert(dbsnpSVEsToInsert, DbsnpSubmittedVariantEntity.class)
+            eva2936DevEnv.bulkUpsert(evaSVEsToInsert, SubmittedVariantEntity.class)
+        }
+    }
+}
+
+[SubmittedVariantEntity.class, DbsnpSubmittedVariantEntity.class].collect{collection ->
+    new EVADataSet<>(null, eva2936DevEnv.mongoTemplate, collection)}.each {dataset -> dataset.each{sves ->
+    sves.groupBy{it.getReferenceSequenceAccession()}.each{String assembly, svesInAssembly ->
+        List<Long> rsIDs = svesInAssembly.collect{it.getClusteredVariantAccession()}
+        // Insert associated RS IDs
+        prodEnv.clusteredVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, rsIDs)
+                .collect{new ClusteredVariantEntity(it.getAccession(), it.getHash(), it.getData(), it.getVersion())}
+                .collate(1000).each{cvesToInsert ->
+            def dbsnpCVEsToInsert = cvesToInsert.findAll{it.getAccession() < evaRSAccessionsLowerBound}
+            def evaCVEsToInsert = cvesToInsert.findAll{it.getAccession() >= evaRSAccessionsLowerBound}
+            logger.info("Inserting ${dbsnpCVEsToInsert.size()} associated RS to DbsnpClusteredVariantEntity in DEV...")
+            logger.info("Inserting ${evaCVEsToInsert.size()} associated RS to ClusteredVariantEntity in DEV...")
+            eva2936DevEnv.bulkUpsert(dbsnpCVEsToInsert, DbsnpClusteredVariantEntity.class)
+            eva2936DevEnv.bulkUpsert(evaCVEsToInsert, ClusteredVariantEntity.class)
+        }
+        // Insert other SS IDs with these RS IDs
+        prodEnv.submittedVariantAccessioningService.getByClusteredVariantAccessionIn(rsIDs)
+                .findAll { it.getData().getReferenceSequenceAccession().equals(assembly)}
+                .collect{new SubmittedVariantEntity(it.getAccession(), it.getHash(), it.getData(), it.getVersion())}
+                .collate(1000).each {svesToInsert ->
+            def dbsnpSVEsToInsert = svesToInsert.findAll{it.getAccession() < evaSSAccessionsLowerBound}
+            def evaSVEsToInsert = svesToInsert.findAll{it.getAccession() >= evaSSAccessionsLowerBound}
+            logger.info("Inserting ${dbsnpSVEsToInsert.size()} associated SS to DbsnpSubmittedVariantEntity in DEV...")
+            logger.info("Inserting ${evaSVEsToInsert.size()} associated SS to SubmittedVariantEntity in DEV...")
+            eva2936DevEnv.bulkUpsert(dbsnpSVEsToInsert, DbsnpSubmittedVariantEntity.class)
+            eva2936DevEnv.bulkUpsert(evaSVEsToInsert, SubmittedVariantEntity.class)
+        }
+}}}
+
+// Backup collections before remediation
+eva2936DevEnv.mongoTemplate.getCollectionNames().each {collectionName ->
+    def before_remediation_suffix = "_before_remediation"
+    if (!collectionName.endsWith(before_remediation_suffix)) {
+        eva2936DevEnv.mongoTemplate.getCollection(collectionName).aggregate(
+                Collections.singletonList(new org.bson.Document("\$out",
+                        "${collectionName}_${before_remediation_suffix}".toString()))).allowDiskUse(true).size()
+    }
+}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/deprecate_eva2936_variants.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/deprecate_eva2936_variants.groovy
@@ -47,9 +47,9 @@ assembliesToDeprecate.each {assembly ->
                     "EVA2936",
                     "Remapped variant had the same SS ID as the one imported from dbSNP. See EVA-2936.")
     logger.info("Deprecating impacted SS in assembly ${assembly}...")
-    def duplicateSSDataSet = new EVADataSet(where("seq").is(assembly), sourceEnv.mongoTemplate,
+    def deprecableSSDataSet = new EVADataSet(where("seq").is(assembly), sourceEnv.mongoTemplate,
             DuplicateSSCategory.class)
-    duplicateSSDataSet.each{duplicateSSEntries ->
+    deprecableSSDataSet.each{duplicateSSEntries ->
         List<Long> ssIDs = duplicateSSEntries.collect{it.accession}
         def svesToDeprecate = sourceEnv.submittedVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, ssIDs)
                 .findAll{Objects.nonNull(it.getData().getRemappedFrom())}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/deprecate_eva2936_variants.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/deprecate_eva2936_variants.groovy
@@ -1,0 +1,59 @@
+package src
+
+@Grab(group='org.codehaus.groovy', module='groovy-cli-commons', version='3.0.10')
+
+import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.query.Criteria
+import src.EVADatabaseEnvironment
+import src.EVADataSet
+import src.DuplicateSSCategory
+import uk.ac.ebi.eva.accession.core.batch.io.SubmittedVariantDeprecationWriter
+import uk.ac.ebi.eva.accession.core.model.dbsnp.DbsnpSubmittedVariantEntity
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.deprecate.Application
+
+import static org.springframework.data.mongodb.core.query.Query.query
+import static org.springframework.data.mongodb.core.query.Criteria.where
+
+def cli = new CliBuilder(usage: 'deprecate_eva2936_variants <source properties file> <destination properties file>')
+def options = cli.parse(args)
+if (options.arguments().size() != 2) {
+    cli.usage()
+    return
+}
+
+// Both can be specified as the same file
+// in which case variants to be deprecated will be read from/output written in the same environment
+def sourcePropertiesFile = options.arguments()[0]
+def destinationPropertiesFile = options.arguments()[1]
+
+def sourceEnv = EVADatabaseEnvironment.createFromSpringContext(sourcePropertiesFile, Application.class)
+def destinationEnv = (destinationPropertiesFile == sourcePropertiesFile)? sourceEnv: EVADatabaseEnvironment.createFromSpringContext(destinationPropertiesFile, Application.class)
+def evaSSAccessionsLowerBound = destinationEnv.springApplicationContext.getBean("accessioningMonotonicInitSs", Long.class)
+def evaRSAccessionsLowerBound = destinationEnv.springApplicationContext.getBean("accessioningMonotonicInitRs", Long.class)
+
+def logger = LoggerFactory.getLogger(this.class)
+
+List<String> assembliesToDeprecate =
+        [SubmittedVariantEntity.class, DbsnpSubmittedVariantEntity.class].collect{collection ->
+            sourceEnv.mongoTemplate.findDistinct(query(new Criteria()), "seq", collection, String.class)
+        }.flatten().unique() as List<String>
+
+assembliesToDeprecate.each {assembly ->
+    def ssDeprecationWriter =
+            new SubmittedVariantDeprecationWriter(assembly, destinationEnv.mongoTemplate,
+                    destinationEnv.submittedVariantAccessioningService,
+                    destinationEnv.clusteredVariantAccessioningService, evaSSAccessionsLowerBound, evaRSAccessionsLowerBound,
+                    "EVA2936",
+                    "Remapped variant had the same SS ID as the one imported from dbSNP. See EVA-2936.")
+    logger.info("Deprecating impacted SS in assembly ${assembly}...")
+    def duplicateSSDataSet = new EVADataSet(where("seq").is(assembly), sourceEnv.mongoTemplate,
+            DuplicateSSCategory.class)
+    duplicateSSDataSet.each{duplicateSSEntries ->
+        List<Long> ssIDs = duplicateSSEntries.collect{it.accession}
+        def svesToDeprecate = sourceEnv.submittedVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, ssIDs)
+                .findAll{Objects.nonNull(it.getData().getRemappedFrom())}
+                .collect{new SubmittedVariantEntity(it.getAccession(), it.getHash(), it.getData(), it.getVersion())}
+        ssDeprecationWriter.write(svesToDeprecate)
+    }
+}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
@@ -8,7 +8,7 @@ import src.DuplicateSSCategory
 import org.slf4j.LoggerFactory
 import uk.ac.ebi.eva.accession.deprecate.Application
 
-def cli = new CliBuilder(usage: 'deprecate_eva2936_variants <source properties file> <destination properties file>')
+def cli = new CliBuilder(usage: 'qc_deprecation <source properties file> <destination properties file>')
 def options = cli.parse(args)
 if (options.arguments().size() != 2) {
     cli.usage()

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
@@ -1,0 +1,38 @@
+package src
+
+@Grab(group='org.codehaus.groovy', module='groovy-cli-commons', version='3.0.10')
+
+import src.EVADatabaseEnvironment
+import src.EVADataSet
+import src.DuplicateSSCategory
+import org.slf4j.LoggerFactory
+import uk.ac.ebi.eva.accession.deprecate.Application
+
+def cli = new CliBuilder(usage: 'deprecate_eva2936_variants <source properties file> <destination properties file>')
+def options = cli.parse(args)
+if (options.arguments().size() != 2) {
+    cli.usage()
+    return
+}
+
+// Both can be specified as the same file
+// in which case variants to be deprecated will be read from/output written in the same environment
+def sourcePropertiesFile = options.arguments()[0]
+def destinationPropertiesFile = options.arguments()[1]
+def sourceEnv = EVADatabaseEnvironment.createFromSpringContext(sourcePropertiesFile, Application.class)
+def destinationEnv = (destinationPropertiesFile == sourcePropertiesFile)? sourceEnv: EVADatabaseEnvironment.createFromSpringContext(destinationPropertiesFile, Application.class)
+
+def logger = LoggerFactory.getLogger(this.class)
+def deprecatedSSDataset = new EVADataSet(null, sourceEnv.mongoTemplate, DuplicateSSCategory.class)
+
+// Ensure that there are no remaining accessions
+// in the three categories mentioned here: https://docs.google.com/spreadsheets/d/1LZbUtamFtQH12SVTfCfYOjcIHWL1OOC_kYnieRLR9UA/edit#rangeid=1722186521
+deprecatedSSDataset.each{it.groupBy {it.getSeq()}.each{String assembly, List<DuplicateSSCategory> dupSSEntries ->
+    List<Long> ssIDs = dupSSEntries.collect{it.getAccession()}
+    destinationEnv.submittedVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, ssIDs)
+            .groupBy {it.getAccession()}.findAll{accession, sves ->
+        // There should not be any accessions from multiple source assemblies
+        return sves.collect{it.getData().getRemappedFrom()}.unique().size() > 1
+    }.each{accession, svesStillInDeprecableCategories ->
+        logger.error("Remapped variants with ss${accession} in ${assembly} should have been deprecated!!")}
+}}

--- a/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
+++ b/tasks/eva_2936/deprecate_inconsistent_remapped_ss/src/qc_deprecation.groovy
@@ -23,11 +23,11 @@ def sourceEnv = EVADatabaseEnvironment.createFromSpringContext(sourcePropertiesF
 def destinationEnv = (destinationPropertiesFile == sourcePropertiesFile)? sourceEnv: EVADatabaseEnvironment.createFromSpringContext(destinationPropertiesFile, Application.class)
 
 def logger = LoggerFactory.getLogger(this.class)
-def deprecatedSSDataset = new EVADataSet(null, sourceEnv.mongoTemplate, DuplicateSSCategory.class)
+def deprecableSSDataset = new EVADataSet(null, sourceEnv.mongoTemplate, DuplicateSSCategory.class)
 
 // Ensure that there are no remaining accessions
 // in the three categories mentioned here: https://docs.google.com/spreadsheets/d/1LZbUtamFtQH12SVTfCfYOjcIHWL1OOC_kYnieRLR9UA/edit#rangeid=1722186521
-deprecatedSSDataset.each{it.groupBy {it.getSeq()}.each{String assembly, List<DuplicateSSCategory> dupSSEntries ->
+deprecableSSDataset.each{it.groupBy {it.getSeq()}.each{String assembly, List<DuplicateSSCategory> dupSSEntries ->
     List<Long> ssIDs = dupSSEntries.collect{it.getAccession()}
     destinationEnv.submittedVariantAccessioningService.getAllActiveByAssemblyAndAccessionIn(assembly, ssIDs)
             .groupBy {it.getAccession()}.findAll{accession, sves ->


### PR DESCRIPTION
Usages [here](https://www.ebi.ac.uk/panda/jira/browse/EVA-2936?focusedCommentId=401573&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-401573)

[DuplicateSSCategory.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-77f9cfc489a4ab8686bbb9c73a58e8a4513fae4faed2ca9fc44a9e081da14ed6) - MongoDB Collection to store results from EVA-2840 pertinent to EVA-2936.

[EVADataSet.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-949e2472fa1c86545a4e2dc43f9fad41de3eddc566b54c6fe1e4bf2fbc0780e8) - Abstraction to represent a subset of data from a MongoDB collection. one [difference](https://www.diffchecker.com/K7vVTCl9) from the older version.

[EVADatabaseEnvironment.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-a6b7a974d317fa86f93d7ee99e42fccf22032057a656ffd0d4747d6d7535916b) - Utility class to provide a "bag of EVA objects" for a given environment (ex: PROD, DEV etc.,) - few [differences](https://www.diffchecker.com/XNcDxw3O) from the [older version](https://github.com/EBIvariation/eva-tasks/blob/f65b1171b7e87289c2fb7735604ef30a67127b5a/tasks/eva_2889/remediate_duplicate_remapped_ss/src/EVADatabaseEnvironment.groovy)

[copy_data_to_eva2936_dev_env.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-a68b05b2b150967e09e9ee075babdf15ed2ac8355c80aeec18dbac1f8ce71e4d) - Script to copy the relevant data for EVA-2936 to the development environment

[deprecate_eva2936_variants.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-38f148922fc53ae54af53b0e043fa7041c80afacb8e31a1be611c4b3e046d99d) - Script to deprecate remapped variants in EVA-2936

[qc_deprecation.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva2936/deprecate_inconsistent_remapped_ssids?expand=1#diff-ba7cef9b9594f0d271993429eed8fd6d7a8964a897433c45b78c817e279a0ee8) - Script to QC deprecation performed by deprecate_eva2936_variants.groovy.