### PR TITLE
EVA-3004 - QC for shelving scripts

### DIFF
--- a/tasks/eva_3004/eva3004/pom.xml
+++ b/tasks/eva_3004/eva3004/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.3</version>
             <type>pom</type>
         </dependency>
     </dependencies>
@@ -58,9 +58,6 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.1.0</version>
-                <configuration>
-                    <executable>java</executable>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/EVACursor.groovy
+++ b/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/EVACursor.groovy
@@ -26,7 +26,7 @@ class EVACursor<T> implements Iterable<T> {
         this.pageSize = pageSize
         this.collectionName = Objects.isNull(collectionName)? this.mongoTemplate.getCollectionName(this.collectionClass): collectionName
 
-        this.resultIterator = this.mongoTemplate.getCollection(collectionName).find(
+        this.resultIterator = this.mongoTemplate.getCollection(this.collectionName).find(
                 this.filterCriteria.criteriaObject).noCursorTimeout(true).batchSize(pageSize).iterator()
     }
 

--- a/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/EVALoggingUtils.groovy
+++ b/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/EVALoggingUtils.groovy
@@ -26,7 +26,6 @@ class EVALoggingUtils {
             fileAppender.setContext(lc)
             fileAppender.start()
             scriptLogger.addAppender(fileAppender)
-            scriptLogger.addAppender(new ConsoleAppender<ILoggingEvent>())
             scriptLogger.setAdditive(false)
         }
         // For interactive use on Emacs terminal, being able to output only to files is desirable

--- a/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva2959_qc_pending_locus_mismatch_reports.groovy
+++ b/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva2959_qc_pending_locus_mismatch_reports.groovy
@@ -63,11 +63,13 @@ def shelveSSWithDiscordantRS = {String assembly, List<Long> rsIDs, String catego
         scriptLogger.error("Pending ${dbsnpSvesToShelve.size()} dbsnp SVEs in assembly ${assembly} in ${category} will be shelved!!")
         scriptLogger.error("${dbsnpSvesToShelve.collect{it.accession}}")
         prodEnv.bulkInsertIgnoreDuplicates(dbsnpSvesToShelve, dbsnpSveClass, shelvedCollectionDbsnpSve)
+        prodEnv.mongoTemplate.findAllAndRemove(query(where("_id").in(dbsnpSvesToShelve.collect{it.id})), dbsnpSveClass)
     }
     if (evaSvesToShelve.size() > 0) {
         scriptLogger.error("Pending ${evaSvesToShelve.size()} EVA SVEs in assembly ${assembly} in ${category} will be shelved!!")
         scriptLogger.error("${evaSvesToShelve.collect{it.accession}}")
         prodEnv.bulkInsertIgnoreDuplicates(evaSvesToShelve, sveClass, shelvedCollectionSve)
+        prodEnv.mongoTemplate.findAllAndRemove(query(where("_id").in(evaSvesToShelve.collect{it.id})), sveClass)
     }
     scriptLogger.info("Scanned ${rsIDs.size()} RS IDs for assembly ${assembly}...")
 }

--- a/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva2959_qc_pending_locus_mismatch_reports.groovy
+++ b/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva2959_qc_pending_locus_mismatch_reports.groovy
@@ -1,0 +1,82 @@
+// This is mostly a copy of qc_eva2959_prod. However, it only checks for pending RS/SS locus mismatches but does NOT shelve any entries.
+
+package uk.ac.ebi.eva.eva3004
+
+import groovy.cli.picocli.CliBuilder
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.deprecate.Application
+import uk.ac.ebi.eva.eva3004.EVADatabaseEnvironment
+import uk.ac.ebi.eva.eva3004.EVALoggingUtils
+
+import static uk.ac.ebi.eva.eva3004.EVADatabaseEnvironment.*
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+
+def cli = new CliBuilder()
+cli.prodPropertiesFile(args:1, longOpt: "prod-props-file", "Production properties file for accessioning",  required: true)
+cli.discordantRSDir(args:1, longOpt: "eva3004-discordant-rs-dir", "Directory containing logs of discordant RS " +
+        "for each assembly ",  required: true)
+def options = cli.parse(args)
+if (!options) {
+    cli.usage()
+    System.exit(1)
+}
+def (prodPropertiesFile, discordantRSDir) = [options.prodPropertiesFile, options.discordantRSDir]
+
+def prodEnv = createFromSpringContext(prodPropertiesFile, Application.class)
+def scriptLogger = EVALoggingUtils.getLogger(this.class)
+
+// SS/RS locus mismatches reported by re-running scripts from EVA-2706 in
+// Two categories:
+// 1) More than one RS locus entry in the clustered variant for a given RS accession (not necessarily that these multiple loci are observed in the assigned SS)
+// 2) More than one position reported for the same RS across multiple SS
+def rsToCheckCategory1 = ["bash", "-c",
+                    "ls -1 ${discordantRSDir}/*pending*errors.log"].execute().text.split("\n").collectEntries{
+    [it.split("/").reverse()[0].split("_pending_errors")[0],
+     ["bash", "-c", "grep \"cluster position\" ${it} | grep -o -E \"for rs[0-9]+\" " +
+             "| grep -o -E \"[0-9]+\""].execute().text.trim().split("\n").findAll{!it.empty}.collect{it.toLong()}.toSet()
+    ]}
+def rsToCheckCategory2 = ["bash", "-c",
+                    "ls -1 ${discordantRSDir}/*pending*errors.log"].execute().text.split("\n").collectEntries{
+    [it.split("/").reverse()[0].split("_pending_errors")[0],
+     ["bash", "-c", "grep \"positions found in submitted variants\" ${it} | grep -o -E \"for rs[0-9]+\" " +
+             "| grep -o -E \"[0-9]+\""].execute().text.trim().split("\n").findAll{!it.empty}.collect{it.toLong()}.toSet()
+    ]}
+// 64,766
+println(rsToCheckCategory1.values().flatten().size())
+// 259
+println(rsToCheckCategory2.values().flatten().size())
+
+def shelvedCollectionDbsnpSve = "eva2706_shelved_dbsnpsve_multi_position_rs"
+def shelvedCollectionSve = "eva2706_shelved_sve_multi_position_rs"
+def shelveSSWithDiscordantRS = {String assembly, List<Long> rsIDs, String category ->
+    List<SubmittedVariantEntity> allSvesWithRS = [sveClass, dbsnpSveClass].collect{prodEnv.mongoTemplate.find(query(where("seq").is(assembly)
+            .and("rs").in(rsIDs)), it)}.flatten()
+    // Ensure that the RS reported with multiple positions among the SS still holds true in the current SVE collections
+    def allSvesToShelve = allSvesWithRS.groupBy{it.clusteredVariantAccession}.findAll{k, v ->
+        v.collect{sve -> EVADatabaseEnvironment.toClusteredVariantEntity(sve).hashedMessage}.unique().size() > 1}.values().flatten()
+
+    def dbsnpSvesToShelve = allSvesToShelve.findAll{it.accession < 5e9}
+    def evaSvesToShelve = allSvesToShelve.findAll{it.accession >= 5e9}
+
+    if (dbsnpSvesToShelve.size() > 0) {
+        scriptLogger.error("Pending ${dbsnpSvesToShelve.size()} dbsnp SVEs in assembly ${assembly} in ${category} will be shelved!!")
+        scriptLogger.error("${dbsnpSvesToShelve.collect{it.accession}}")
+        prodEnv.bulkInsertIgnoreDuplicates(dbsnpSvesToShelve, dbsnpSveClass, shelvedCollectionDbsnpSve)
+    }
+    if (evaSvesToShelve.size() > 0) {
+        scriptLogger.error("Pending ${evaSvesToShelve.size()} EVA SVEs in assembly ${assembly} in ${category} will be shelved!!")
+        scriptLogger.error("${evaSvesToShelve.collect{it.accession}}")
+        prodEnv.bulkInsertIgnoreDuplicates(evaSvesToShelve, sveClass, shelvedCollectionSve)
+    }
+    scriptLogger.info("Scanned ${rsIDs.size()} RS IDs for assembly ${assembly}...")
+}
+
+def category = "category 1"
+rsToCheckCategory1.each{assembly, allRSIDs -> allRSIDs.collate(1000).each { rsIDs ->
+    shelveSSWithDiscordantRS(assembly, rsIDs, category)
+}}
+category = "category 2"
+rsToCheckCategory2.each{assembly, allRSIDs -> allRSIDs.collate(1000).each { rsIDs ->
+    shelveSSWithDiscordantRS(assembly, rsIDs, category)
+}}

--- a/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva3011_check_sve_with_mapweight_rs.groovy
+++ b/tasks/eva_3004/eva3004/src/uk/ac/ebi/eva/eva3004/eva3011_check_sve_with_mapweight_rs.groovy
@@ -7,6 +7,7 @@ package uk.ac.ebi.eva.eva3004
 
 import groovy.cli.picocli.CliBuilder
 import uk.ac.ebi.eva.eva3004.EVACursor
+import uk.ac.ebi.eva.eva3004.EVALoggingUtils
 import uk.ac.ebi.eva.accession.deprecate.Application
 
 import static uk.ac.ebi.eva.eva3004.EVADatabaseEnvironment.*
@@ -21,11 +22,12 @@ if (!options) {
     System.exit(1)
 }
 def prodEnv = createFromSpringContext(options.prodPropertiesFile, Application.class)
+def scriptLogger = EVALoggingUtils.getLogger(this.class)
 
 // All the assemblies in DbsnpClusteredVariantEntity collection
 def allAssemblies = ["GCA_000001215.2","GCA_000001215.4","GCA_000001515.4","GCA_000001515.5","GCA_000001545.3","GCA_000001635.4","GCA_000001635.5","GCA_000001635.6","GCA_000001635.9","GCA_000001735.1","GCA_000001895.3","GCA_000001895.4","GCA_000002035.2","GCA_000002035.3","GCA_000002035.4","GCA_000002175.2","GCA_000002195.1","GCA_000002255.2","GCA_000002265.1","GCA_000002285.1","GCA_000002285.2","GCA_000002305.1","GCA_000002315.1","GCA_000002315.2","GCA_000002315.3","GCA_000002315.5","GCA_000002655.1","GCA_000002775.1","GCA_000002775.3","GCA_000003025.4","GCA_000003025.6","GCA_000003055.3","GCA_000003055.5","GCA_000003195.1","GCA_000003195.3","GCA_000003205.1","GCA_000003205.4","GCA_000003205.6","GCA_000003625.1","GCA_000003745.2","GCA_000004515.2","GCA_000004515.3","GCA_000004515.4","GCA_000004665.1","GCA_000005005.5","GCA_000005005.6","GCA_000005425.2","GCA_000005575.1","GCA_000146605.2","GCA_000146605.3","GCA_000146605.4","GCA_000146795.3","GCA_000148765.2","GCA_000151805.2","GCA_000151905.1","GCA_000151905.3","GCA_000181335.3","GCA_000181335.4","GCA_000188115.2","GCA_000188115.3","GCA_000188235.2","GCA_000219495.1","GCA_000219495.2","GCA_000224145.1","GCA_000224145.2","GCA_000233375.4","GCA_000247795.2","GCA_000247815.2","GCA_000298735.1","GCA_000298735.2","GCA_000309985.1","GCA_000317375.1","GCA_000317765.1","GCA_000331145.1","GCA_000364345.1","GCA_000409795.2","GCA_000442705.1","GCA_000512255.2","GCA_000686985.1","GCA_000695525.1","GCA_000710875.1","GCA_000751015.1","GCA_000772875.3","GCA_000987745.1","GCA_001433935.1","GCA_001465895.2","GCA_001522545.1","GCA_001522545.2","GCA_001577835.1","GCA_001625215.1","GCA_001704415.1","GCA_001858045.3","GCA_002114115.1","GCA_002263795.2","GCA_002754865.1","GCA_002863925.1","GCA_002880775.3","GCA_003254395.2","GCA_003339765.3","GCA_003957565.2","GCA_011100615.1","GCA_014441545.1","GCA_015227675.2","GCA_016772045.1","GCA_902167145.1"]
 allAssemblies.each{assembly ->
-    println("Processing assembly ${assembly}...")
+    scriptLogger.info("Processing assembly ${assembly}...")
     def dbsnpCvesWithMapWtSet = new EVACursor(where("asm").is(assembly).and("mapWeight").exists(true),
             prodEnv.mongoTemplate, dbsnpCveClass)
     dbsnpCvesWithMapWtSet.each{dbsnpCvesInBatch ->
@@ -38,7 +40,7 @@ allAssemblies.each{assembly ->
         def svesSplitFromDbsnpSS = prodEnv.mongoTemplate.find(query(where("_id")
                 .regex("SS_SPLIT_.*").and("splitInto").in(ssIDsWithMapWtRS)), dbsnpSvoeClass)
         (ssIDsWithMapWtRS - svesSplitFromDbsnpSS.collect{it.splitInto}).each {
-            println("SS ID ${it} likely clustered with a map-weighted RS...")
+            scriptLogger.error("SS ID ${it} likely clustered with a map-weighted RS...")
         }
     }
 }


### PR DESCRIPTION
Usages for almost all of these can be found in the [ticket comments](https://www.ebi.ac.uk/panda/jira/browse/EVA-3004) except for the script [eva3001_create_svoe_entries_for_rs_merges.groovy](https://github.com/EBIvariation/eva-tasks/compare/master...sundarvenkata-EBI:eva-tasks:eva3004/shelve_problematic_ss_rs?expand=1#diff-4156609dd43771a73fca03552635e641a69241d832672290099f1da3cdb7147c) which was used to create SVOE entries corresponding to merges created in EVA-2850.

