### PR TITLE
EVA-3151 - Deal with circular merge situations

### DIFF
--- a/tasks/eva_2205/src/main/groovy/eva2205/eva2205_utils.groovy
+++ b/tasks/eva_2205/src/main/groovy/eva2205/eva2205_utils.groovy
@@ -33,15 +33,29 @@ static List getChronologicalMergeChain(List svoeOpsForAGivenSS) {
             opWithOriginalSS = opsWithSrcRS[0]
         }
     }
-    if (Objects.isNull(opWithOriginalSS)) throw new IllegalArgumentException("Could not locate source RS for the SS " +
-            "with the following operations: \n" + svoeOpsForAGivenSS.join("\n"))
+    /** There are scenarios (see example below) where there could be circular merges leaving no way to find a definitive original SS record!!
+     * In those cases, use Submitted Variant createdDate (NOT the createdDate for the merge operation which was unfortunately not available for old records)
+     * as a best-effort proxy (possibly not accurate!) to identify the original SS record
+     * DbsnpSubmittedVariantOperationEntity{id='5d554066d7d16e435e2b24ea', accession=316150381, reason='Original rs196349204 was merged into rs195124461.'
+     DbsnpSubmittedVariantOperationEntity{id='5d554066d7d16e435e2b24ee', accession=315919449, reason='Original rs195124461 was merged into rs196349204.'
+     */
+    if (Objects.isNull(opWithOriginalSS)) {
+        opWithOriginalSS = svoeOpsForAGivenSS.sort { op1, op2 ->
+            op1.inactiveObjects[0].createdDate.compareTo(op2.inactiveObjects[0].createdDate)}[0]
+    }
     def mergeChain = Arrays.asList(opWithOriginalSS)
     def destRSIDToLookFor = getMatchedComponent(opWithOriginalSS, "destination")
+    def previouslyEncounteredRS = new HashSet<String>([getMatchedComponent(opWithOriginalSS, "source")])
     while(true) {
         if(!opsGroupedByRSSource.containsKey(destRSIDToLookFor)) break
+        previouslyEncounteredRS.add(destRSIDToLookFor)
         def nextOpInChain = opsGroupedByRSSource.get(destRSIDToLookFor)[0]
         mergeChain += nextOpInChain
         destRSIDToLookFor = getMatchedComponent(nextOpInChain, "destination")
+        // When encountering circular reference ex: rs3 -> rs2 -> rs1 -> rs3
+        // break chain at rs1 whose destRSIDToLookFor will be rs3
+        // See https://www.ebi.ac.uk/panda/jira/browse/EVA-3151?focusedId=418704&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418704
+        if(previouslyEncounteredRS.contains(destRSIDToLookFor)) break
     }
     return mergeChain
 }


### PR DESCRIPTION
Deprecation process for 6 out of 114 assemblies failed due to the issue of circular merges described [here](https://www.ebi.ac.uk/panda/jira/browse/EVA-3151?focusedId=418704&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-418704). This PR addresses the issue by picking one record as the definitive original SS record in such situations.