### PR TITLE
EVA-3174 - Deprecate variants with asmMatch false

### DIFF
--- a/tasks/eva_3174/logback.xml
+++ b/tasks/eva_3174/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %5p %40.40c:%4L - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="info"/>
+    <logger name="uk.ac.ebi.eva" level="info"/>
+
+    <root level="error">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/tasks/eva_3174/pom.xml
+++ b/tasks/eva_3174/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>uk.ac.ebi.eva</groupId>
+    <artifactId>eva_3174</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>4.0.3</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.ampt2d</groupId>
+            <artifactId>accession-commons-core</artifactId>
+            <version>0.7.10-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-common-groovyutils</artifactId>
+            <version>0.1-SNAPSHOT</version>
+            <exclusions>
+                <!-- Exclude accession commons old version since we are going to use
+                EventType with UNDO merge from the new version updated with this PR -->
+                <exclusion>
+                    <groupId>uk.ac.ebi.ampt2d</groupId>
+                    <artifactId>accession-commons-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-accession-deprecate</artifactId>
+            <exclusions>
+                <!-- Exclude accession commons old version since we are going to use
+                EventType with UNDO merge from the new version updated with this PR -->
+                <exclusion>
+                    <groupId>uk.ac.ebi.ampt2d</groupId>
+                    <artifactId>accession-commons-core</artifactId>
+                </exclusion>
+            </exclusions>
+            <version>0.6.16-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.3.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.13.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>compile</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sources>
+                        <source>
+                            <directory>${project.basedir}/src</directory>
+                            <includes>
+                                <include>**/*.groovy</include>
+                            </includes>
+                        </source>
+                    </sources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>cloudsmith</id>
+            <url>https://dl.cloudsmith.io/public/ebivariation/packages/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <eva.mongo.host.test>localhost</eva.mongo.host.test>
+    </properties>
+
+</project>

--- a/tasks/eva_3174/src/main/groovy/eva3174/eva3174_deprecate_asmmatch_false_rs.groovy
+++ b/tasks/eva_3174/src/main/groovy/eva3174/eva3174_deprecate_asmmatch_false_rs.groovy
@@ -1,0 +1,67 @@
+package eva3174
+
+import groovy.cli.picocli.CliBuilder
+import org.slf4j.LoggerFactory
+
+import uk.ac.ebi.eva.accession.clustering.metric.ClusteringMetric
+import uk.ac.ebi.eva.accession.core.GenericApplication
+import uk.ac.ebi.eva.accession.core.batch.io.ClusteredVariantDeprecationWriter
+import uk.ac.ebi.eva.accession.deprecate.Application
+import uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment
+import uk.ac.ebi.eva.groovy.commons.EVAObjectModelUtils
+import uk.ac.ebi.eva.groovy.commons.RetryableBatchingCursor
+import uk.ac.ebi.eva.metrics.metric.MetricCompute
+
+import static uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment.*
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+
+def cli = new CliBuilder()
+cli.propertiesFile(args:1, "Properties file to use for deprecation", required: true)
+cli.assemblyToDeprecate(args:1, "Assembly where RS corresponding to asmMatch=false should be deprecated", required: true)
+def options = cli.parse(args)
+if (!options) {
+    cli.usage()
+    System.exit(1)
+}
+
+class DeprecateRSWithAsmMatchFalseLocus {
+    EVADatabaseEnvironment dbEnv
+    MetricCompute metricCompute
+    String assembly
+    Long dbsnpRSIDUpperBound
+    static def logger = LoggerFactory.getLogger(GenericApplication.class)
+
+    DeprecateRSWithAsmMatchFalseLocus(EVADatabaseEnvironment dbEnv, String assembly) {
+        this.dbEnv = dbEnv
+        this.assembly = assembly
+        this.dbsnpRSIDUpperBound = dbEnv.springApplicationContext.getBean("accessioningMonotonicInitRs", Long.class)
+        this.metricCompute = dbEnv.springApplicationContext.getBean(MetricCompute.class)
+    }
+
+    def deprecateRS() {
+        def asmMatchCursorDbsnpSve = [dbsnpSvoeClass, svoeClass].collect{new RetryableBatchingCursor<>(
+                where("inactiveObjects.seq").is(this.assembly).and("_id").regex("SS_DEPRECATED_EVA3174_.*"),
+                this.dbEnv.mongoTemplate, it)}.flatten()
+        asmMatchCursorDbsnpSve.each {it.each{deprecatedAsmMatchOps ->
+            def cveHashesToDeprecate = deprecatedAsmMatchOps.collect{
+                EVAObjectModelUtils.getClusteredVariantHash(it.inactiveObjects[0])}
+            def cvesToDeprecate = [cveClass, dbsnpCveClass].collect{
+                dbEnv.mongoTemplate.find(query(where("_id").in(cveHashesToDeprecate)), it)}.flatten()
+            logger.info("Deprecating ${cvesToDeprecate.size()} CVEs in assembly ${this.assembly}...")
+            def cvDeprecationWriter = new ClusteredVariantDeprecationWriter(this.assembly,
+                    dbEnv.mongoTemplate, dbEnv.submittedVariantAccessioningService, dbsnpRSIDUpperBound,
+                    "EVA3174", "Variant deprecated due to allelesMatch=false")
+            // By the design of the write, this will only succeed if these RS IDs are orphaned i.e., there are no SS that have these RS IDs
+            cvDeprecationWriter.write(cvesToDeprecate)
+            this.metricCompute.addCount(ClusteringMetric.CLUSTERED_VARIANTS_DEPRECATED,
+                    cvDeprecationWriter.numDeprecatedEntities)
+            this.metricCompute.saveMetricsCountsInDB()
+        }}
+    }
+}
+
+EVADatabaseEnvironment dbEnv = createFromSpringContext(options.propertiesFile, Application.class,
+        ["parameters.assemblyAccession": options.assemblyToDeprecate])
+def deprecateObj = new DeprecateRSWithAsmMatchFalseLocus(dbEnv, options.assemblyToDeprecate)
+deprecateObj.deprecateRS()

--- a/tasks/eva_3174/src/main/groovy/eva3174/eva3174_deprecate_asmmatch_false_variants.groovy
+++ b/tasks/eva_3174/src/main/groovy/eva3174/eva3174_deprecate_asmmatch_false_variants.groovy
@@ -1,0 +1,101 @@
+package eva3174
+
+import groovy.cli.picocli.CliBuilder
+import org.springframework.batch.core.JobParameter
+import org.springframework.batch.core.JobParameters
+import org.springframework.batch.core.StepExecutionListener
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.launch.support.RunIdIncrementer
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.item.ExecutionContext
+import org.springframework.batch.item.ItemStreamException
+import org.springframework.batch.item.ItemStreamReader
+import org.springframework.batch.item.NonTransientResourceException
+import org.springframework.batch.item.UnexpectedInputException
+import org.springframework.batch.repeat.policy.SimpleCompletionPolicy
+import org.springframework.transaction.PlatformTransactionManager
+
+import uk.ac.ebi.eva.accession.core.batch.io.SubmittedVariantDeprecationWriter
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.deprecate.Application
+import uk.ac.ebi.eva.accession.deprecate.batch.listeners.DeprecationStepProgressListener
+import uk.ac.ebi.eva.accession.deprecate.parameters.InputParameters
+import uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment
+import uk.ac.ebi.eva.groovy.commons.RetryableBatchingCursor
+import uk.ac.ebi.eva.metrics.metric.MetricCompute
+
+import java.text.ParseException
+import java.time.LocalDateTime
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment.*
+
+// This script deprecates variants having asmMatch false in dbsnpSVE collection and also the corresponding RS (if any)
+def cli = new CliBuilder()
+cli.propertiesFile(args: 1, "Properties file to use for deprecation", required: true)
+cli.assemblyToDeprecate(args: 1, "Assembly where variants with asmMatch=false should be deprecated", required: true)
+def options = cli.parse(args)
+if (!options) {
+    cli.usage()
+    System.exit(1)
+}
+
+class DeprecateAsmMatchFalseSS {
+
+    static void deprecateSS(EVADatabaseEnvironment dbEnv, Collection<? extends SubmittedVariantEntity> svesToDeprecate) {
+        if (svesToDeprecate.size() == 0) return
+        def inputParameters = dbEnv.springApplicationContext.getBean(InputParameters.class)
+        def svDeprecationWriter = new SubmittedVariantDeprecationWriter(inputParameters.assemblyAccession,
+                dbEnv.mongoTemplate,
+                dbEnv.submittedVariantAccessioningService, dbEnv.clusteredVariantAccessioningService,
+                dbEnv.springApplicationContext.getBean("accessioningMonotonicInitSs", Long.class),
+                dbEnv.springApplicationContext.getBean("accessioningMonotonicInitRs", Long.class),
+                "EVA3174", "Variant deprecated due to asmMatch=false")
+        def dbEnvProgressListener =
+                new DeprecationStepProgressListener(svDeprecationWriter, dbEnv.springApplicationContext.getBean(MetricCompute.class))
+
+        def dbEnvJobRepository = dbEnv.springApplicationContext.getBean(JobRepository.class)
+        def dbEnvTxnMgr = dbEnv.springApplicationContext.getBean(PlatformTransactionManager.class)
+
+        def dbEnvJobBuilderFactory = new JobBuilderFactory(dbEnvJobRepository)
+        def dbEnvStepBuilderFactory = new StepBuilderFactory(dbEnvJobRepository, dbEnvTxnMgr)
+
+        def mapWtSSIterator = svesToDeprecate.iterator()
+        def svDeprecateJobSteps = dbEnvStepBuilderFactory.get("stepsForSSDeprecation").chunk(new SimpleCompletionPolicy(inputParameters.chunkSize)).reader(
+                new ItemStreamReader<SubmittedVariantEntity>() {
+                    @Override
+                    SubmittedVariantEntity read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+                        return mapWtSSIterator.hasNext() ? mapWtSSIterator.next() : null
+                    }
+
+                    @Override
+                    void open(ExecutionContext executionContext) throws ItemStreamException {
+
+                    }
+
+                    @Override
+                    void update(ExecutionContext executionContext) throws ItemStreamException {
+
+                    }
+
+                    @Override
+                    void close() throws ItemStreamException {
+
+                    }
+                }).writer(svDeprecationWriter).listener((StepExecutionListener) dbEnvProgressListener).build()
+
+        def svDeprecationJob = dbEnvJobBuilderFactory.get("deprecationJob").start(svDeprecateJobSteps).incrementer(
+                new RunIdIncrementer()).build()
+        def dbEnvJobLauncher = dbEnv.springApplicationContext.getBean(JobLauncher.class)
+        dbEnvJobLauncher.run(svDeprecationJob, new JobParameters(["executionDate": new JobParameter(
+                LocalDateTime.now().toDate())]))
+    }
+}
+
+def dbEnv = createFromSpringContext(options.propertiesFile, Application.class,
+        ["parameters.assemblyAccession": options.assemblyToDeprecate])
+def asmMatchFalseVariantCursor = [sveClass, dbsnpSveClass].collect{new RetryableBatchingCursor(where("seq")
+        .is(options.assemblyToDeprecate).and("asmMatch").is(false), dbEnv.mongoTemplate, it)}
+asmMatchFalseVariantCursor.each{it.each{sves -> DeprecateAsmMatchFalseSS.deprecateSS(dbEnv, sves)}}


### PR DESCRIPTION
* eva3174_deprecate_asmmatch_false_variants.groovy - Script that was used to deprecate SS with allelesMatch false was [slightly modified](https://www.diffchecker.com/BexiMUCe/) to adapt to deprecate SS with asmMatch false

* eva3174_deprecate_asmmatch_false_rs.groovy - Script to deprecate RS with the locus from SS deprecated above (if not already deprecated by the above script due to mismatching SS/RS locus). This script is mostly used for verification and is normally expected to report zero deprecations.

Usage [here](https://www.ebi.ac.uk/panda/jira/browse/EVA-3174?focusedId=420482&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-420482)