### PR TITLE
EVA-3238 - Scripts to deprecate variants remapped from allelesMatch false

### DIFF
--- a/tasks/eva_3238/logback.xml
+++ b/tasks/eva_3238/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %5p %40.40c:%4L - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="info"/>
+    <logger name="uk.ac.ebi.eva" level="info"/>
+
+    <root level="error">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/tasks/eva_3238/pom.xml
+++ b/tasks/eva_3238/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>uk.ac.ebi.eva</groupId>
+    <artifactId>eva_3238</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>4.0.3</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.ampt2d</groupId>
+            <artifactId>accession-commons-core</artifactId>
+            <version>0.7.10-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-common-groovyutils</artifactId>
+            <version>0.2-SNAPSHOT</version>
+            <exclusions>
+                <!-- Exclude accession commons old version since we are going to use
+                EventType with UNDO merge from the new version updated with this PR -->
+                <exclusion>
+                    <groupId>uk.ac.ebi.ampt2d</groupId>
+                    <artifactId>accession-commons-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-accession-deprecate</artifactId>
+            <exclusions>
+                <!-- Exclude accession commons old version since we are going to use
+                EventType with UNDO merge from the new version updated with this PR -->
+                <exclusion>
+                    <groupId>uk.ac.ebi.ampt2d</groupId>
+                    <artifactId>accession-commons-core</artifactId>
+                </exclusion>
+            </exclusions>
+            <version>0.6.19-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.3.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.13.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>compile</goal>
+                            <goal>compileTests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sources>
+                        <source>
+                            <directory>${project.basedir}/src</directory>
+                            <includes>
+                                <include>**/*.groovy</include>
+                            </includes>
+                        </source>
+                    </sources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>cloudsmith</id>
+            <url>https://dl.cloudsmith.io/public/ebivariation/packages/maven/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <eva.mongo.host.test>localhost</eva.mongo.host.test>
+    </properties>
+
+</project>

--- a/tasks/eva_3238/src/main/groovy/eva3238/eva3238_deprecate_ambiguous_remapped.groovy
+++ b/tasks/eva_3238/src/main/groovy/eva3238/eva3238_deprecate_ambiguous_remapped.groovy
@@ -1,0 +1,35 @@
+package eva3238
+
+import eva3238.DeprecateRemappedAllelesMatchFalseSS
+import groovy.cli.picocli.CliBuilder
+import uk.ac.ebi.eva.accession.deprecate.Application
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+import static uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment.*
+
+// This script deprecates variants remapped from variants having allelesMatch false in dbsnpSVE collection
+// but had duplicate SS IDs in the remapped assembly
+// So, remapping was carried out for the impacted variants in source assembly
+// and the resultant remapped variants were placed in the DEV environment
+// Since these resultant variants unambiguously show the remapped hashes, they can be readily deprecated from PROD
+def cli = new CliBuilder()
+cli.prodPropertiesFile(args: 1, "Production properties file to use for deprecation", required: true)
+cli.devPropertiesFile(args: 1, "Development properties file to use", required: true)
+cli.remappedAssembly(args: 1, "Remapped assembly", required: true)
+def options = cli.parse(args)
+if (!options) {
+    cli.usage()
+    System.exit(1)
+}
+
+def prodEnv = createFromSpringContext(options.prodPropertiesFile, Application.class,
+        ["parameters.assemblyAccession": options.remappedAssembly])
+def devEnv = createFromSpringContext(options.devPropertiesFile, Application.class,
+        ["parameters.assemblyAccession": options.remappedAssembly])
+def ssHashesToDeprecate = devEnv.mongoTemplate.find(query(where("remappedFrom").exists(true)),
+        dbsnpSveClass).collect{it.hashedMessage}
+def svesToDeprecateInProd = [sveClass, dbsnpSveClass].collect {collectionClass ->
+    prodEnv.mongoTemplate.find(query(where("_id").in(ssHashesToDeprecate)), collectionClass)
+}.flatten()
+DeprecateRemappedAllelesMatchFalseSS.deprecateSS(prodEnv, svesToDeprecateInProd)

--- a/tasks/eva_3238/src/main/groovy/eva3238/eva3238_deprecate_remapped_allelesmatch_false_ss.groovy
+++ b/tasks/eva_3238/src/main/groovy/eva3238/eva3238_deprecate_remapped_allelesmatch_false_ss.groovy
@@ -1,0 +1,114 @@
+package eva3238
+
+import groovy.cli.picocli.CliBuilder
+import org.springframework.batch.core.JobParameter
+import org.springframework.batch.core.JobParameters
+import org.springframework.batch.core.StepExecutionListener
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.batch.core.launch.support.RunIdIncrementer
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.item.ExecutionContext
+import org.springframework.batch.item.ItemStreamException
+import org.springframework.batch.item.ItemStreamReader
+import org.springframework.batch.item.NonTransientResourceException
+import org.springframework.batch.item.UnexpectedInputException
+import org.springframework.batch.repeat.policy.SimpleCompletionPolicy
+import org.springframework.transaction.PlatformTransactionManager
+
+import uk.ac.ebi.eva.accession.core.batch.io.SubmittedVariantDeprecationWriter
+import uk.ac.ebi.eva.accession.core.model.eva.SubmittedVariantEntity
+import uk.ac.ebi.eva.accession.deprecate.Application
+import uk.ac.ebi.eva.accession.deprecate.batch.listeners.DeprecationStepProgressListener
+import uk.ac.ebi.eva.accession.deprecate.parameters.InputParameters
+import uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment
+import uk.ac.ebi.eva.groovy.commons.RetryableBatchingCursor
+import uk.ac.ebi.eva.metrics.metric.MetricCompute
+
+import java.text.ParseException
+import java.time.LocalDateTime
+
+import static org.springframework.data.mongodb.core.query.Criteria.where
+import static org.springframework.data.mongodb.core.query.Query.query
+import static uk.ac.ebi.eva.groovy.commons.EVADatabaseEnvironment.*
+
+class DeprecateRemappedAllelesMatchFalseSS {
+
+    static void deprecateSS(EVADatabaseEnvironment dbEnv, Collection<? extends SubmittedVariantEntity> svesToDeprecate) {
+        if (svesToDeprecate.size() == 0) return
+        def inputParameters = dbEnv.springApplicationContext.getBean(InputParameters.class)
+        def svDeprecationWriter = new SubmittedVariantDeprecationWriter(inputParameters.assemblyAccession,
+                dbEnv.mongoTemplate,
+                dbEnv.submittedVariantAccessioningService, dbEnv.clusteredVariantAccessioningService,
+                dbEnv.springApplicationContext.getBean("accessioningMonotonicInitSs", Long.class),
+                dbEnv.springApplicationContext.getBean("accessioningMonotonicInitRs", Long.class),
+                "EVA3238", "Variant remapped from an allelesMatch=false variant")
+        def dbEnvProgressListener =
+                new DeprecationStepProgressListener(svDeprecationWriter, dbEnv.springApplicationContext.getBean(MetricCompute.class))
+
+        def dbEnvJobRepository = dbEnv.springApplicationContext.getBean(JobRepository.class)
+        def dbEnvTxnMgr = dbEnv.springApplicationContext.getBean(PlatformTransactionManager.class)
+
+        def dbEnvJobBuilderFactory = new JobBuilderFactory(dbEnvJobRepository)
+        def dbEnvStepBuilderFactory = new StepBuilderFactory(dbEnvJobRepository, dbEnvTxnMgr)
+
+        def mapWtSSIterator = svesToDeprecate.iterator()
+        def svDeprecateJobSteps = dbEnvStepBuilderFactory.get("stepsForSSDeprecation").chunk(new SimpleCompletionPolicy(inputParameters.chunkSize)).reader(
+                new ItemStreamReader<SubmittedVariantEntity>() {
+                    @Override
+                    SubmittedVariantEntity read() throws Exception, UnexpectedInputException, ParseException, NonTransientResourceException {
+                        return mapWtSSIterator.hasNext() ? mapWtSSIterator.next() : null
+                    }
+
+                    @Override
+                    void open(ExecutionContext executionContext) throws ItemStreamException {
+
+                    }
+
+                    @Override
+                    void update(ExecutionContext executionContext) throws ItemStreamException {
+
+                    }
+
+                    @Override
+                    void close() throws ItemStreamException {
+
+                    }
+                }).writer(svDeprecationWriter).listener((StepExecutionListener) dbEnvProgressListener).build()
+
+        def svDeprecationJob = dbEnvJobBuilderFactory.get("deprecationJob").start(svDeprecateJobSteps).incrementer(
+                new RunIdIncrementer()).build()
+        def dbEnvJobLauncher = dbEnv.springApplicationContext.getBean(JobLauncher.class)
+        dbEnvJobLauncher.run(svDeprecationJob, new JobParameters(["executionDate": new JobParameter(
+                LocalDateTime.now().toDate())]))
+    }
+}
+
+// This script deprecates variants remapped from variants having allelesMatch false in dbsnpSVE collection
+// and also the corresponding RS (if any)
+def cli = new CliBuilder()
+cli.prodPropertiesFile(args: 1, "Production properties file to use for deprecation", required: true)
+cli.originalAssembly(args: 1, "Source assembly with deprecated allelesMatch=false variants", required: true)
+cli.remappedAssembly(args: 1, "Remapped assembly", required: true)
+def options = cli.parse(args)
+if (!options) {
+    cli.usage()
+    System.exit(1)
+}
+
+def prodEnv = createFromSpringContext(options.prodPropertiesFile, Application.class,
+        ["parameters.assemblyAccession": options.remappedAssembly])
+def allelesMatchFalseVariantCursor = [svoeClass, dbsnpSvoeClass].collect{
+    new RetryableBatchingCursor(where("inactiveObjects.seq").is(options.originalAssembly)
+            .and("_id").regex("SS_DEPRECATED_EVA3101_.*"), prodEnv.mongoTemplate, it)}
+allelesMatchFalseVariantCursor.each{it.each{svoes ->
+    def accessionsToLookupInRemappedAssembly = svoes.collect{it.accession}
+    def matchingSSInRemappedAssembly = [sveClass, dbsnpSveClass].collect{
+        prodEnv.mongoTemplate.find(query(where("seq").is(options.remappedAssembly)
+                .and("remappedFrom").is(options.originalAssembly)
+                .and("accession").in(accessionsToLookupInRemappedAssembly)), it)}.flatten().groupBy{it.accession}
+    // Deprecate matching SS with no duplicates in the remapped assembly
+    DeprecateRemappedAllelesMatchFalseSS.deprecateSS(prodEnv,
+            matchingSSInRemappedAssembly.findAll{it.value.size() == 1}.values().flatten())
+}}


### PR DESCRIPTION
Scripts were copied verbatim from EVA-3179 and the asmMatch attribute was replaced with allelesMatch attribute. Diffs [here](https://www.diffchecker.com/qLAs7aTw/) and [here](https://www.diffchecker.com/o8HCrxpw/)