### PR TITLE
EVA-3238 - Use updated dependencies that fix ambiguous RestTemplate bean issue

### DIFF
--- a/tasks/eva_3238/pom.xml
+++ b/tasks/eva_3238/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>eva-metrics</artifactId>
+            <version>0.0.4-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>eva-common-groovyutils</artifactId>
             <version>0.2-SNAPSHOT</version>
             <exclusions>
@@ -45,7 +50,7 @@
                     <artifactId>accession-commons-core</artifactId>
                 </exclusion>
             </exclusions>
-            <version>0.6.19-SNAPSHOT</version>
+            <version>0.6.20-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
See [here](https://github.com/EBIvariation/eva-accession/pull/389#issue-1698673241)